### PR TITLE
 Move variables to prevent duplicates

### DIFF
--- a/includes/daemon.h
+++ b/includes/daemon.h
@@ -45,7 +45,7 @@ typedef struct {
 
 
 
-struct request_queue * render_request_queue;
+extern struct request_queue * render_request_queue;
 
 void statsRenderFinish(int z, long time);
 void request_exit(void);

--- a/includes/render_submit_queue.h
+++ b/includes/render_submit_queue.h
@@ -5,8 +5,6 @@ extern "C" {
 #endif
 
 
-int work_complete;
-
 void enqueue(const char *xmlname, int x, int y, int z);
 void spawn_workers(int num, const char *socketpath, int maxLoad);
 void wait_for_empty_queue(void);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -49,6 +49,8 @@ static renderd_config config;
 
 int noSlaveRenders;
 
+struct request_queue * render_request_queue;
+
 
 static const char *cmdStr(enum protoCmd c)
 {

--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -89,7 +89,6 @@ unsigned long long twopow[MAX_ZOOM];
 static int minZoom = 0;
 static int maxZoom = 18;
 static int verbose = 0;
-int work_complete;
 static int maxLoad = MAX_LOAD_OLD;
 
 void display_rate(struct timeval start, struct timeval end, int num) 

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -40,8 +40,6 @@ static int maxZoom = MAX_ZOOM;
 static int verbose = 0;
 static int maxLoad = MAX_LOAD_OLD;
 
-int work_complete;
-
 void display_rate(struct timeval start, struct timeval end, int num) 
 {
     int d_s, d_us;

--- a/src/render_old.c
+++ b/src/render_old.c
@@ -47,8 +47,6 @@ static time_t planetTime;
 static struct timeval start, end;
 
 
-int work_complete;
-
 void display_rate(struct timeval start, struct timeval end, int num) 
 {
     int d_s, d_us;

--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -47,6 +47,8 @@ static struct qItem *qHead, *qTail;
 
 static int no_workers;
 static pthread_t *workers;
+static int work_complete;
+
 
 static void check_load(void)
 {


### PR DESCRIPTION
This allows newer versions of `gcc` to compile this project by resolving duplicate definitions such as this one:
```
/usr/bin/ld: src/renderd-gen_tile.o:./mod_tile/./includes/daemon.h:48: multiple definition of `render_request_queue'; src/daemon.o:./mod_tile/./includes/daemon.h:48: first defined here
```

Based on the patch from here:
https://github.com/openstreetmap/mod_tile/compare/master...jburgess777:compile-fixes.patch