### PR TITLE
Logging Improvements

### DIFF
--- a/includes/daemon.h
+++ b/includes/daemon.h
@@ -26,6 +26,7 @@ typedef struct {
     char *mapnik_font_dir;
     int mapnik_font_dir_recurse;
     char * stats_filename;
+    char * log_priority;
 } renderd_config;
 
 typedef struct {

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -51,6 +51,8 @@ int noSlaveRenders;
 
 struct request_queue *render_request_queue;
 
+int log_priority;
+
 static const char *cmdStr(enum protoCmd c) {
   switch (c) {
   case cmdIgnore:
@@ -86,7 +88,8 @@ void send_response(struct item *item, enum protoCmd rsp, int render_time) {
         ((req->cmd == cmdRender) || (req->cmd == cmdRenderPrio) ||
          (req->cmd == cmdRenderBulk))) {
       req->cmd = rsp;
-      // fprintf(stderr, "Sending message %s to %d\n", cmdStr(rsp), item->fd);
+      syslog(LOG_DEBUG, "DEBUG: Sending message %s to %d\n", cmdStr(rsp),
+             item->fd);
 
       send_cmd(req, item->fd);
     }
@@ -107,7 +110,7 @@ enum protoCmd rx_request(struct protocol *req, int fd) {
     strcpy(req->mimetype, "image/png");
     strcpy(req->options, "");
   } else if (req->ver != 3) {
-    syslog(LOG_ERR, "Bad protocol version %d", req->ver);
+    syslog(LOG_ERR, "ERROR: Bad protocol version %d\n", req->ver);
     return cmdNotDone;
   }
 
@@ -129,7 +132,7 @@ enum protoCmd rx_request(struct protocol *req, int fd) {
 
   item = (struct item *)malloc(sizeof(*item));
   if (!item) {
-    syslog(LOG_ERR, "malloc failed");
+    syslog(LOG_ERR, "ERROR: malloc failed");
     return cmdNotDone;
   }
 
@@ -156,7 +159,8 @@ void request_exit(void) {
   // Any write to the exit pipe will trigger a graceful exit
   char c = 0;
   if (write(exit_pipe_fd, &c, sizeof(c)) < 0) {
-    fprintf(stderr, "Failed to write to the exit pipe: %s\n", strerror(errno));
+    syslog(LOG_ERR, "ERROR: Failed to write to the exit pipe: %s\n",
+           strerror(errno));
   }
 }
 
@@ -171,7 +175,7 @@ void process_loop(int listen_fd) {
   // A pipe is used to allow the render threads to request an exit by the main
   // process
   if (pipe(pipefds)) {
-    fprintf(stderr, "Failed to create pipe\n");
+    syslog(LOG_ERR, "ERROR: Failed to create pipe");
     return;
   }
   exit_pipe_fd = pipefds[1];
@@ -204,7 +208,7 @@ void process_loop(int listen_fd) {
         break;
       }
 
-      // printf("Data is available now on %d fds\n", num);
+      syslog(LOG_DEBUG, "DEBUG: Data is available now on %d fds", num);
       if (FD_ISSET(listen_fd, &rd)) {
         num--;
         incoming = accept(listen_fd, (struct sockaddr *)&in_addr, &in_addrlen);
@@ -212,9 +216,10 @@ void process_loop(int listen_fd) {
           perror("accept()");
         } else {
           if (num_connections == MAX_CONNECTIONS) {
-            syslog(LOG_WARNING,
-                   "Connection limit(%d) reached. Dropping connection\n",
-                   MAX_CONNECTIONS);
+            syslog(
+                LOG_WARNING,
+                "WARNING: Connection limit(%d) reached. Dropping connection\n",
+                MAX_CONNECTIONS);
             close(incoming);
           } else {
             connections[num_connections++] = incoming;
@@ -257,7 +262,7 @@ void process_loop(int listen_fd) {
         }
       }
     } else {
-      syslog(LOG_ERR, "Select timeout");
+      syslog(LOG_ERR, "ERROR: Select timeout");
     }
   }
 }
@@ -280,7 +285,7 @@ void *stats_writeout_thread(void *arg) {
 
   snprintf(tmpName, sizeof(tmpName), "%s.tmp", config.stats_filename);
 
-  syslog(LOG_DEBUG, "Starting stats thread");
+  syslog(LOG_DEBUG, "DEBUG: Starting stats thread");
   while (1) {
     request_queue_copy_stats(render_request_queue, &lStats);
 
@@ -297,7 +302,7 @@ void *stats_writeout_thread(void *arg) {
 
     FILE *statfile = fopen(tmpName, "w");
     if (statfile == NULL) {
-      syslog(LOG_WARNING, "Failed to open stats file: %i", errno);
+      syslog(LOG_WARNING, "WARNING: Failed to open stats file: %i\n", errno);
       noFailedAttempts++;
       if (noFailedAttempts > 3) {
         syslog(LOG_ERR, "ERROR: Failed repeatedly to write stats, giving up");
@@ -331,7 +336,8 @@ void *stats_writeout_thread(void *arg) {
       }
       fclose(statfile);
       if (rename(tmpName, config.stats_filename)) {
-        syslog(LOG_WARNING, "Failed to overwrite stats file: %i", errno);
+        syslog(LOG_WARNING, "WARNING: Failed to overwrite stats file: %i\n",
+               errno);
         noFailedAttempts++;
         if (noFailedAttempts > 3) {
           syslog(LOG_ERR,
@@ -355,7 +361,7 @@ int client_socket_init(renderd_config *sConfig) {
   char ipstring[INET6_ADDRSTRLEN];
 
   if (sConfig->ipport > 0) {
-    syslog(LOG_INFO, "Initialising TCP/IP client socket to %s:%i",
+    syslog(LOG_INFO, "INFO: Initialising TCP/IP client socket to %s:%i\n",
            sConfig->iphostname, sConfig->ipport);
 
     memset(&hints, 0, sizeof(struct addrinfo));
@@ -370,7 +376,7 @@ int client_socket_init(renderd_config *sConfig) {
 
     s = getaddrinfo(sConfig->iphostname, portnum, &hints, &result);
     if (s != 0) {
-      syslog(LOG_INFO, "failed to resolve hostname of rendering slave");
+      syslog(LOG_INFO, "INFO: failed to resolve hostname of rendering slave");
       return FD_INVALID;
     }
 
@@ -391,15 +397,17 @@ int client_socket_init(renderd_config *sConfig) {
                  rp->ai_family);
         break;
       }
-      syslog(LOG_DEBUG, "Connecting TCP socket to rendering daemon at %s",
+      syslog(LOG_DEBUG,
+             "DEBUG: Connecting TCP socket to rendering daemon at %s\n",
              ipstring);
       fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
       if (fd < 0)
         continue;
       if (connect(fd, rp->ai_addr, rp->ai_addrlen) != 0) {
-        syslog(LOG_INFO,
-               "failed to connect to rendering daemon (%s), trying next ip",
-               ipstring);
+        syslog(
+            LOG_INFO,
+            "INFO: failed to connect to rendering daemon (%s), trying next ip",
+            ipstring);
         close(fd);
         fd = -1;
         continue;
@@ -410,20 +418,20 @@ int client_socket_init(renderd_config *sConfig) {
     freeaddrinfo(result);
 
     if (fd < 0) {
-      syslog(LOG_WARNING, "failed to connect to %s:%i", sConfig->iphostname,
-             sConfig->ipport);
+      syslog(LOG_WARNING, "WARNING: failed to connect to %s:%i\n",
+             sConfig->iphostname, sConfig->ipport);
       return FD_INVALID;
     }
 
-    syslog(LOG_INFO, "socket %s:%i initialised to fd %i", sConfig->iphostname,
-           sConfig->ipport, fd);
+    syslog(LOG_INFO, "INFO: socket %s:%i initialised to fd %i\n",
+           sConfig->iphostname, sConfig->ipport, fd);
   } else {
-    syslog(LOG_INFO, "Initialising unix client socket on %s",
+    syslog(LOG_INFO, "INFO: Initialising unix client socket on %s\n",
            sConfig->socketname);
     addrU = (struct sockaddr_un *)malloc(sizeof(struct sockaddr_un));
     fd = socket(PF_UNIX, SOCK_STREAM, 0);
     if (fd < 0) {
-      syslog(LOG_WARNING, "Could not obtain socket: %i", fd);
+      syslog(LOG_WARNING, "WARNING: Could not obtain socket: %i\n", fd);
       free(addrU);
       return FD_INVALID;
     }
@@ -433,13 +441,15 @@ int client_socket_init(renderd_config *sConfig) {
     strncpy(addrU->sun_path, sConfig->socketname, sizeof(addrU->sun_path) - 1);
 
     if (connect(fd, (struct sockaddr *)addrU, sizeof(struct sockaddr_un)) < 0) {
-      syslog(LOG_WARNING, "socket connect failed for: %s", sConfig->socketname);
+      syslog(LOG_WARNING, "WARNING: socket connect failed for: %s\n",
+             sConfig->socketname);
       close(fd);
       free(addrU);
       return FD_INVALID;
     }
     free(addrU);
-    syslog(LOG_INFO, "socket %s initialised to fd %i", sConfig->socketname, fd);
+    syslog(LOG_INFO, "INFO: socket %s initialised to fd %i\n",
+           sConfig->socketname, fd);
   }
   return fd;
 }
@@ -451,11 +461,11 @@ int server_socket_init(renderd_config *sConfig) {
   int fd;
 
   if (sConfig->ipport > 0) {
-    syslog(LOG_INFO, "Initialising TCP/IP server socket on %s:%i",
+    syslog(LOG_INFO, "INFO: Initialising TCP/IP server socket on %s:%i\n",
            sConfig->iphostname, sConfig->ipport);
     fd = socket(PF_INET6, SOCK_STREAM, 0);
     if (fd < 0) {
-      fprintf(stderr, "failed to create IP socket\n");
+      syslog(LOG_CRIT, "CRITICAL: failed to create IP socket");
       exit(2);
     }
     bzero(&addrI, sizeof(addrI));
@@ -463,18 +473,18 @@ int server_socket_init(renderd_config *sConfig) {
     addrI.sin6_addr = in6addr_any;
     addrI.sin6_port = htons(sConfig->ipport);
     if (bind(fd, (struct sockaddr *)&addrI, sizeof(addrI)) < 0) {
-      fprintf(stderr, "socket bind failed for: %s:%i\n", sConfig->iphostname,
-              sConfig->ipport);
+      syslog(LOG_CRIT, "CRITICAL: socket bind failed for: %s:%i\n",
+             sConfig->iphostname, sConfig->ipport);
       close(fd);
       exit(3);
     }
   } else {
-    syslog(LOG_INFO, "Initialising unix server socket on %s",
+    syslog(LOG_INFO, "INFO: Initialising unix server socket on %s\n",
            sConfig->socketname);
 
     fd = socket(PF_UNIX, SOCK_STREAM, 0);
     if (fd < 0) {
-      fprintf(stderr, "failed to create unix socket\n");
+      syslog(LOG_CRIT, "CRITICAL: failed to create unix socket");
       exit(2);
     }
 
@@ -486,7 +496,8 @@ int server_socket_init(renderd_config *sConfig) {
 
     old = umask(0); // Need daemon socket to be writeable by apache
     if (bind(fd, (struct sockaddr *)&addrU, sizeof(addrU)) < 0) {
-      fprintf(stderr, "socket bind failed for: %s\n", sConfig->socketname);
+      syslog(LOG_CRIT, "CRITICAL: socket bind failed for: %s\n",
+             sConfig->socketname);
       close(fd);
       exit(3);
     }
@@ -494,12 +505,12 @@ int server_socket_init(renderd_config *sConfig) {
   }
 
   if (listen(fd, QUEUE_MAX) < 0) {
-    fprintf(stderr, "socket listen failed for %d\n", QUEUE_MAX);
+    syslog(LOG_CRIT, "CRITICAL: socket listen failed for %d\n", QUEUE_MAX);
     close(fd);
     exit(4);
   }
 
-  syslog(LOG_DEBUG, "Created server socket %i", fd);
+  syslog(LOG_DEBUG, "DEBUG: Created server socket %i\n", fd);
 
   return fd;
 }
@@ -535,14 +546,16 @@ void *slave_thread(void *arg) {
       if (pfd == FD_INVALID) {
         if (sConfig->ipport > 0) {
           syslog(LOG_ERR,
-                 "Failed to connect to render slave %s:%i, trying again in 30 "
+                 "ERROR: Failed to connect to render slave %s:%i, trying again "
+                 "in 30 "
                  "seconds",
                  sConfig->iphostname, sConfig->ipport);
         } else {
-          syslog(LOG_ERR,
-                 "Failed to connect to render slave %s, trying again in 30 "
-                 "seconds",
-                 sConfig->socketname);
+          syslog(
+              LOG_ERR,
+              "ERROR: Failed to connect to render slave %s, trying again in 30 "
+              "seconds",
+              sConfig->socketname);
         }
         sleep(30);
         continue;
@@ -564,7 +577,8 @@ void *slave_thread(void *arg) {
 
       /*Dispatch request to slave renderd*/
       retry = 2;
-      syslog(LOG_INFO, "Dispatching request to slave thread on fd %i", pfd);
+      syslog(LOG_INFO, "INFO: Dispatching request to slave thread on fd %i\n",
+             pfd);
       do {
         ret_size = send_cmd(req_slave, pfd);
 
@@ -574,20 +588,22 @@ void *slave_thread(void *arg) {
         }
 
         if (errno != EPIPE) {
-          syslog(LOG_ERR,
-                 "Failed to send cmd to render slave, shutting down thread");
+          syslog(LOG_ERR, "ERROR: Failed to send cmd to render slave, shutting "
+                          "down thread");
           free(resp);
           free(req_slave);
           close(pfd);
           return NULL;
         }
 
-        syslog(LOG_WARNING, "Failed to send cmd to render slave, retrying");
+        syslog(LOG_WARNING,
+               "WARNING: Failed to send cmd to render slave, retrying");
         close(pfd);
         pfd = client_socket_init(sConfig);
         if (pfd == FD_INVALID) {
-          syslog(LOG_ERR,
-                 "Failed to re-connect to render slave, dropping request");
+          syslog(
+              LOG_ERR,
+              "ERROR: Failed to re-connect to render slave, dropping request");
           ret = cmdNotDone;
           send_response(item, ret, -1);
           break;
@@ -606,7 +622,7 @@ void *slave_thread(void *arg) {
           close(pfd);
           pfd = FD_INVALID;
           ret_size = 0;
-          syslog(LOG_ERR, "Pipe to render slave closed");
+          syslog(LOG_ERR, "ERROR: Pipe to render slave closed");
           break;
         }
         retry--;
@@ -614,12 +630,14 @@ void *slave_thread(void *arg) {
       if (ret_size < sizeof(struct protocol)) {
         if (sConfig->ipport > 0) {
           syslog(LOG_ERR,
-                 "Invalid reply from render slave %s:%i, trying again in 30 "
+                 "ERROR: Invalid reply from render slave %s:%i, trying again "
+                 "in 30 "
                  "seconds",
                  sConfig->iphostname, sConfig->ipport);
         } else {
           syslog(LOG_ERR,
-                 "Invalid reply render slave %s, trying again in 30 seconds",
+                 "ERROR: Invalid reply render slave %s, trying again in 30 "
+                 "seconds",
                  sConfig->socketname);
         }
 
@@ -632,11 +650,13 @@ void *slave_thread(void *arg) {
         if (resp->cmd != cmdDone) {
           if (sConfig->ipport > 0) {
             syslog(LOG_ERR,
-                   "Request from render slave %s:%i did not complete correctly",
+                   "ERROR: Request from render slave %s:%i did not complete "
+                   "correctly",
                    sConfig->iphostname, sConfig->ipport);
           } else {
             syslog(LOG_ERR,
-                   "Request from render slave %s did not complete correctly",
+                   "ERROR: Request from render slave %s did not complete "
+                   "correctly",
                    sConfig->socketname);
           }
           // Sleep for a while to make sure we don't overload the renderer
@@ -715,14 +735,14 @@ int main(int argc, char **argv) {
 #endif
   openlog("renderd", log_options, LOG_DAEMON);
 
-  syslog(LOG_INFO, "Rendering daemon started");
+  syslog(LOG_INFO, "INFO: Rendering daemon started");
 
   render_request_queue = request_queue_init();
   if (render_request_queue == NULL) {
-    syslog(LOG_ERR, "Failed to initialise request queue");
+    syslog(LOG_ERR, "ERROR: Failed to initialise request queue");
     exit(1);
   }
-  syslog(LOG_ERR, "Initiating request_queue");
+  syslog(LOG_INFO, "INFO: Initialising request_queue");
 
   xmlconfigitem maps[XMLCONFIGS_MAX];
   bzero(maps, sizeof(xmlconfigitem) * XMLCONFIGS_MAX);
@@ -742,22 +762,23 @@ int main(int argc, char **argv) {
   char buffer[PATH_MAX];
   for (int section = 0; section < iniparser_getnsec(ini); section++) {
     char *name = iniparser_getsecname(ini, section);
-    syslog(LOG_INFO, "Parsing section %s\n", name);
+    syslog(LOG_INFO, "INFO: Parsing section %s\n", name);
     if (strncmp(name, "renderd", 7) && strcmp(name, "mapnik")) {
       if (config.tile_dir == NULL) {
-        fprintf(stderr, "No valid (active) renderd config section available\n");
+        syslog(LOG_CRIT,
+               "CRITICAL: No valid (active) renderd config section available");
         exit(7);
       }
       /* this is a map section */
       iconf++;
       if (iconf >= XMLCONFIGS_MAX) {
-        fprintf(stderr, "Config: more than %d configurations found\n",
-                XMLCONFIGS_MAX);
+        syslog(LOG_CRIT, "CRITICAL: Config: more than %d configurations found",
+               XMLCONFIGS_MAX);
         exit(7);
       }
 
       if (strlen(name) >= (XMLCONFIG_MAX - 1)) {
-        fprintf(stderr, "XML name too long: %s\n", name);
+        syslog(LOG_CRIT, "CRITICAL: XML name too long: %s\n", name);
         exit(7);
       }
 
@@ -766,7 +787,7 @@ int main(int argc, char **argv) {
       sprintf(buffer, "%s:uri", name);
       char *ini_uri = iniparser_getstring(ini, buffer, (char *)"");
       if (strlen(ini_uri) >= (PATH_MAX - 1)) {
-        fprintf(stderr, "URI too long: %s\n", ini_uri);
+        syslog(LOG_CRIT, "CRITICAL: URI too long: %s\n", ini_uri);
         exit(7);
       }
       strcpy(maps[iconf].xmluri, ini_uri);
@@ -774,7 +795,7 @@ int main(int argc, char **argv) {
       sprintf(buffer, "%s:xml", name);
       char *ini_xmlpath = iniparser_getstring(ini, buffer, (char *)"");
       if (strlen(ini_xmlpath) >= (PATH_MAX - 1)) {
-        fprintf(stderr, "XML path too long: %s\n", ini_xmlpath);
+        syslog(LOG_CRIT, "CRITICAL: XML path too long: %s\n", ini_xmlpath);
         exit(7);
       }
       strcpy(maps[iconf].xmlfile, ini_xmlpath);
@@ -782,7 +803,7 @@ int main(int argc, char **argv) {
       sprintf(buffer, "%s:host", name);
       char *ini_hostname = iniparser_getstring(ini, buffer, (char *)"");
       if (strlen(ini_hostname) >= (PATH_MAX - 1)) {
-        fprintf(stderr, "Host name too long: %s\n", ini_hostname);
+        syslog(LOG_CRIT, "CRITICAL: Host name too long: %s\n", ini_hostname);
         exit(7);
       }
       strcpy(maps[iconf].host, ini_hostname);
@@ -790,7 +811,7 @@ int main(int argc, char **argv) {
       sprintf(buffer, "%s:htcphost", name);
       char *ini_htcpip = iniparser_getstring(ini, buffer, (char *)"");
       if (strlen(ini_htcpip) >= (PATH_MAX - 1)) {
-        fprintf(stderr, "HTCP host name too long: %s\n", ini_htcpip);
+        syslog(LOG_CRIT, "CRITICAL: HTCP host name too long: %s\n", ini_htcpip);
         exit(7);
       }
       strcpy(maps[iconf].htcpip, ini_htcpip);
@@ -799,7 +820,7 @@ int main(int argc, char **argv) {
       char *ini_tilesize = iniparser_getstring(ini, buffer, (char *)"256");
       maps[iconf].tile_px_size = atoi(ini_tilesize);
       if (maps[iconf].tile_px_size < 1) {
-        fprintf(stderr, "Tile size is invalid: %s\n", ini_tilesize);
+        syslog(LOG_CRIT, "CRITICAL: Tile size is invalid: %s\n", ini_tilesize);
         exit(7);
       }
 
@@ -807,7 +828,7 @@ int main(int argc, char **argv) {
       char *ini_scale = iniparser_getstring(ini, buffer, (char *)"1.0");
       maps[iconf].scale_factor = atof(ini_scale);
       if (maps[iconf].scale_factor < 0.1 || maps[iconf].scale_factor > 8.0) {
-        fprintf(stderr, "Scale factor is invalid: %s\n", ini_scale);
+        syslog(LOG_CRIT, "CRITICAL: Scale factor is invalid: %s\n", ini_scale);
         exit(7);
       }
 
@@ -815,7 +836,7 @@ int main(int argc, char **argv) {
       char *ini_tiledir =
           iniparser_getstring(ini, buffer, (char *)config.tile_dir);
       if (strlen(ini_tiledir) >= (PATH_MAX - 1)) {
-        fprintf(stderr, "Tiledir too long: %s\n", ini_tiledir);
+        syslog(LOG_CRIT, "CRITICAL: Tiledir too long: %s\n", ini_tiledir);
         exit(7);
       }
       strcpy(maps[iconf].tile_dir, ini_tiledir);
@@ -824,10 +845,10 @@ int main(int argc, char **argv) {
       char *ini_maxzoom = iniparser_getstring(ini, buffer, "18");
       maps[iconf].max_zoom = atoi(ini_maxzoom);
       if (maps[iconf].max_zoom > MAX_ZOOM) {
-        fprintf(stderr,
-                "Specified max zoom (%i) is to large. Renderd currently only "
-                "supports up to zoom level %i\n",
-                maps[iconf].max_zoom, MAX_ZOOM);
+        syslog(LOG_CRIT,
+               "CRITICAL: Specified max zoom (%i) is too large. Renderd "
+               "currently only supports up to zoom level %i\n",
+               maps[iconf].max_zoom, MAX_ZOOM);
         exit(7);
       }
 
@@ -835,23 +856,25 @@ int main(int argc, char **argv) {
       char *ini_minzoom = iniparser_getstring(ini, buffer, "0");
       maps[iconf].min_zoom = atoi(ini_minzoom);
       if (maps[iconf].min_zoom < 0) {
-        fprintf(stderr,
-                "Specified min zoom (%i) is to small. Minimum zoom level has "
-                "to be greater or equal to 0\n",
-                maps[iconf].min_zoom);
+        syslog(LOG_CRIT,
+               "CRITICAL: Specified min zoom (%i) is too small. Minimum zoom "
+               "level has to be greater or equal to 0",
+               maps[iconf].min_zoom);
         exit(7);
       }
       if (maps[iconf].min_zoom > maps[iconf].max_zoom) {
-        fprintf(stderr,
-                "Specified min zoom (%i) is larger than max zoom (%i).\n",
-                maps[iconf].min_zoom, maps[iconf].max_zoom);
+        syslog(
+            LOG_CRIT,
+            "CRITICAL: Specified min zoom (%i) is larger than max zoom (%i).",
+            maps[iconf].min_zoom, maps[iconf].max_zoom);
         exit(7);
       }
 
       sprintf(buffer, "%s:parameterize_style", name);
       char *ini_parameterize = iniparser_getstring(ini, buffer, "");
       if (strlen(ini_parameterize) >= (PATH_MAX - 1)) {
-        fprintf(stderr, "Parameterize_style too long: %s\n", ini_parameterize);
+        syslog(LOG_CRIT, "CRITICAL: Parameterize_style too long: %s\n",
+               ini_parameterize);
         exit(7);
       }
       strcpy(maps[iconf].parameterization, ini_parameterize);
@@ -866,9 +889,9 @@ int main(int argc, char **argv) {
       if (sscanf(name, "renderd%i", &render_sec) != 1) {
         render_sec = 0;
       }
-      syslog(LOG_INFO, "Parsing render section %i\n", render_sec);
+      syslog(LOG_INFO, "INFO: Parsing render section %i\n", render_sec);
       if (render_sec >= MAX_SLAVES) {
-        syslog(LOG_ERR, "Can't handle more than %i render sections\n",
+        syslog(LOG_ERR, "ERROR: Can't handle more than %i render sections\n",
                MAX_SLAVES);
         exit(7);
       }
@@ -889,6 +912,9 @@ int main(int argc, char **argv) {
       sprintf(buffer, "%s:stats_file", name);
       config_slaves[render_sec].stats_filename =
           iniparser_getstring(ini, buffer, NULL);
+      sprintf(buffer, "%s:log_priority", name);
+      config_slaves[render_sec].log_priority =
+          iniparser_getstring(ini, buffer, "error");
 
       if (render_sec == active_slave) {
         config.socketname = config_slaves[render_sec].socketname;
@@ -897,6 +923,7 @@ int main(int argc, char **argv) {
         config.num_threads = config_slaves[render_sec].num_threads;
         config.tile_dir = config_slaves[render_sec].tile_dir;
         config.stats_filename = config_slaves[render_sec].stats_filename;
+        config.log_priority = config_slaves[render_sec].log_priority;
         config.mapnik_plugins_dir = iniparser_getstring(
             ini, "mapnik:plugins_dir", (char *)MAPNIK_PLUGINS);
         config.mapnik_font_dir =
@@ -910,66 +937,86 @@ int main(int argc, char **argv) {
   }
 
   if (config.ipport > 0) {
-    syslog(LOG_INFO, "config renderd: ip socket=%s:%i\n", config.iphostname,
-           config.ipport);
+    syslog(LOG_INFO, "INFO: config renderd: ip socket=%s:%i\n",
+           config.iphostname, config.ipport);
   } else {
-    syslog(LOG_INFO, "config renderd: unix socketname=%s\n", config.socketname);
+    syslog(LOG_INFO, "INFO: config renderd: unix socketname=%s\n",
+           config.socketname);
   }
-  syslog(LOG_INFO, "config renderd: num_threads=%d\n", config.num_threads);
+  syslog(LOG_INFO, "INFO: config renderd: num_threads=%d\n",
+         config.num_threads);
   if (active_slave == 0) {
-    syslog(LOG_INFO, "config renderd: num_slaves=%d\n", noSlaveRenders);
+    syslog(LOG_INFO, "INFO: config renderd: num_slaves=%d\n", noSlaveRenders);
   }
-  syslog(LOG_INFO, "config renderd: tile_dir=%s\n", config.tile_dir);
-  syslog(LOG_INFO, "config renderd: stats_file=%s\n", config.stats_filename);
-  syslog(LOG_INFO, "config mapnik:  plugins_dir=%s\n",
+  syslog(LOG_INFO, "INFO: config renderd: tile_dir=%s\n", config.tile_dir);
+  syslog(LOG_INFO, "INFO: config renderd: stats_file=%s\n",
+         config.stats_filename);
+  syslog(LOG_INFO, "INFO: config renderd: log_priority=%s\n",
+         config.log_priority);
+  syslog(LOG_INFO, "INFO: config mapnik:  plugins_dir=%s\n",
          config.mapnik_plugins_dir);
-  syslog(LOG_INFO, "config mapnik:  font_dir=%s\n", config.mapnik_font_dir);
-  syslog(LOG_INFO, "config mapnik:  font_dir_recurse=%d\n",
+  syslog(LOG_INFO, "INFO: config mapnik:  font_dir=%s\n",
+         config.mapnik_font_dir);
+  syslog(LOG_INFO, "INFO: config mapnik:  font_dir_recurse=%d\n",
          config.mapnik_font_dir_recurse);
   for (i = 0; i < MAX_SLAVES; i++) {
     if (config_slaves[i].num_threads == 0) {
       continue;
     }
     if (i == active_slave) {
-      syslog(LOG_INFO, "config renderd(%i): Active\n", i);
+      syslog(LOG_INFO, "INFO: config renderd(%i): Active\n", i);
     }
     if (config_slaves[i].ipport > 0) {
-      syslog(LOG_INFO, "config renderd(%i): ip socket=%s:%i\n", i,
+      syslog(LOG_INFO, "INFO: config renderd(%i): ip socket=%s:%i\n", i,
              config_slaves[i].iphostname, config_slaves[i].ipport);
     } else {
-      syslog(LOG_INFO, "config renderd(%i): unix socketname=%s\n", i,
+      syslog(LOG_INFO, "INFO: config renderd(%i): unix socketname=%s\n", i,
              config_slaves[i].socketname);
     }
-    syslog(LOG_INFO, "config renderd(%i): num_threads=%d\n", i,
+    syslog(LOG_INFO, "INFO: config renderd(%i): num_threads=%d\n", i,
            config_slaves[i].num_threads);
-    syslog(LOG_INFO, "config renderd(%i): tile_dir=%s\n", i,
+    syslog(LOG_INFO, "INFO: config renderd(%i): tile_dir=%s\n", i,
            config_slaves[i].tile_dir);
-    syslog(LOG_INFO, "config renderd(%i): stats_file=%s\n", i,
+    syslog(LOG_INFO, "INFO: config renderd(%i): stats_file=%s\n", i,
            config_slaves[i].stats_filename);
+    syslog(LOG_INFO, "INFO: config renderd(%i): log_priority=%s\n", i,
+           config_slaves[i].log_priority);
   }
+
+  if (strcmp(config.log_priority, "debug") == 0) {
+    log_priority = LOG_DEBUG;
+  } else if (strcmp(config.log_priority, "info") == 0) {
+    log_priority = LOG_INFO;
+  } else if (strcmp(config.log_priority, "warning") == 0) {
+    log_priority = LOG_WARNING;
+  } else {
+    log_priority = LOG_ERR;
+  }
+  setlogmask(LOG_UPTO(log_priority));
 
   for (iconf = 0; iconf < XMLCONFIGS_MAX; ++iconf) {
     if (maps[iconf].xmlname[0] != 0) {
-      syslog(LOG_INFO,
-             "config map %d:   name(%s) file(%s) uri(%s) htcp(%s) host(%s)",
-             iconf, maps[iconf].xmlname, maps[iconf].xmlfile,
-             maps[iconf].xmluri, maps[iconf].htcpip, maps[iconf].host);
+      syslog(
+          LOG_INFO,
+          "INFO: config map %d:   name(%s) file(%s) uri(%s) htcp(%s) host(%s)",
+          iconf, maps[iconf].xmlname, maps[iconf].xmlfile, maps[iconf].xmluri,
+          maps[iconf].htcpip, maps[iconf].host);
     }
   }
 
   fd = server_socket_init(&config);
 #if 0
     if (fcntl(fd, F_SETFD, O_RDWR | O_NONBLOCK) < 0) {
-        fprintf(stderr, "setting socket non-block failed\n");
-        close(fd);
-        exit(5);
+      syslog(LOG_CRIT, "CRITICAL: setting socket non-block failed");
+      close(fd);
+      exit(5);
     }
 #endif
 
   // sigPipeAction.sa_handler = pipe_handler;
   sigPipeAction.sa_handler = SIG_IGN;
   if (sigaction(SIGPIPE, &sigPipeAction, NULL) < 0) {
-    fprintf(stderr, "failed to register signal handler\n");
+    syslog(LOG_CRIT, "CRITICAL: failed to register signal handler");
     close(fd);
     exit(6);
   }
@@ -980,10 +1027,10 @@ int main(int argc, char **argv) {
   /* unless the command line said to run in foreground mode, fork and detach
    * from terminal */
   if (foreground) {
-    fprintf(stderr, "Running in foreground mode...\n");
+    syslog(LOG_INFO, "INFO: Running in foreground mode...");
   } else {
     if (daemon(0, 0) != 0) {
-      fprintf(stderr, "can't daemonize: %s\n", strerror(errno));
+      syslog(LOG_ERR, "ERROR: can't daemonize: %s\n", strerror(errno));
     }
     /* write pid file */
     FILE *pidfile = fopen(PIDFILE, "w");
@@ -995,18 +1042,18 @@ int main(int argc, char **argv) {
 
   if (config.stats_filename != NULL) {
     if (pthread_create(&stats_thread, NULL, stats_writeout_thread, NULL)) {
-      syslog(LOG_WARNING, "Could not create stats writeout thread");
+      syslog(LOG_WARNING, "WARNING: Could not create stats writeout thread");
     }
   } else {
     syslog(LOG_INFO,
-           "No stats file specified in config. Stats reporting disabled");
+           "INFO: No stats file specified in config. Stats reporting disabled");
   }
 
   render_threads = (pthread_t *)malloc(sizeof(pthread_t) * config.num_threads);
 
   for (i = 0; i < config.num_threads; i++) {
     if (pthread_create(&render_threads[i], NULL, render_thread, (void *)maps)) {
-      fprintf(stderr, "error spawning render thread\n");
+      syslog(LOG_CRIT, "ERROR: error spawning render thread");
       close(fd);
       exit(7);
     }
@@ -1020,7 +1067,7 @@ int main(int argc, char **argv) {
       for (j = 0; j < config_slaves[i].num_threads; j++) {
         if (pthread_create(&slave_threads[k++], NULL, slave_thread,
                            (void *)&config_slaves[i])) {
-          fprintf(stderr, "error spawning render thread\n");
+          syslog(LOG_CRIT, "ERROR: error spawning render thread");
           close(fd);
           exit(7);
         }

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -1,66 +1,67 @@
-#include <mapnik/version.hpp>
-#include <mapnik/map.hpp>
-#include <mapnik/layer.hpp>
-#include <mapnik/datasource.hpp>
-#include <mapnik/feature_type_style.hpp>
-#include <mapnik/datasource_cache.hpp>
 #include <mapnik/agg_renderer.hpp>
-#include <mapnik/load_map.hpp>
+#include <mapnik/datasource.hpp>
+#include <mapnik/datasource_cache.hpp>
+#include <mapnik/feature_type_style.hpp>
 #include <mapnik/image_util.hpp>
+#include <mapnik/layer.hpp>
+#include <mapnik/load_map.hpp>
+#include <mapnik/map.hpp>
+#include <mapnik/version.hpp>
 
-#include <exception>
-#include <iostream>
-#include <fstream>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/time.h>
 #include <dirent.h>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <syslog.h>
 #include <unistd.h>
-#include <pthread.h>
-#include <string>
-#include <stdlib.h>
 
-#include "gen_tile.h"
-#include "render_config.h"
-#include "daemon.h"
-#include "store.h"
-#include "metatile.h"
-#include "protocol.h"
-#include "request_queue.h"
 #include "cache_expire.h"
+#include "daemon.h"
+#include "gen_tile.h"
+#include "metatile.h"
 #include "parameterize_style.hpp"
+#include "protocol.h"
+#include "render_config.h"
+#include "request_queue.h"
+#include "store.h"
+
+extern int log_priority;
 
 #ifdef HTCP_EXPIRE_CACHE
-#include <sys/socket.h>
 #include <netdb.h>
+#include <sys/socket.h>
 #endif
 
 #if MAPNIK_VERSION >= 300000
-    #define image_data_32 image_rgba8
-    #define image_32 image_rgba8
-    #include <mapnik/image.hpp>
-    #include <mapnik/image_view_any.hpp>
+#define image_data_32 image_rgba8
+#define image_32 image_rgba8
+#include <mapnik/image.hpp>
+#include <mapnik/image_view_any.hpp>
 #else
-    #include <mapnik/graphics.hpp>
-    #if MAPNIK_VERSION < 200000
-        #include <mapnik/envelope.hpp>
-        #define image_32 Image32
-        #define image_data_32 ImageData32
-        #define box2d Envelope
-        #define zoom_to_box zoomToBox
-    #else
-        #include <mapnik/box2d.hpp>
-    #endif
+#include <mapnik/graphics.hpp>
+#if MAPNIK_VERSION < 200000
+#include <mapnik/envelope.hpp>
+#define image_32 Image32
+#define image_data_32 ImageData32
+#define box2d Envelope
+#define zoom_to_box zoomToBox
+#else
+#include <mapnik/box2d.hpp>
 #endif
-
+#endif
 
 using namespace mapnik;
 #ifndef DEG_TO_RAD
-#define DEG_TO_RAD (M_PI/180)
+#define DEG_TO_RAD (M_PI / 180)
 #endif
 #ifndef RAD_TO_DEG
-#define RAD_TO_DEG (180/M_PI)
+#define RAD_TO_DEG (180 / M_PI)
 #endif
 
 #ifdef METATILE
@@ -70,416 +71,500 @@ using namespace mapnik;
 #endif
 
 struct projectionconfig {
-    double bound_x0;
-    double bound_y0;
-    double bound_x1;
-    double bound_y1;
-    int    aspect_x;
-    int    aspect_y;
+  double bound_x0;
+  double bound_y0;
+  double bound_x1;
+  double bound_y1;
+  int aspect_x;
+  int aspect_y;
 };
 
 struct xmlmapconfig {
-    char xmlname[XMLCONFIG_MAX];
-    char xmlfile[PATH_MAX];
-    struct storage_backend * store;
-    Map map;
-    struct projectionconfig * prj;
-    char xmluri[PATH_MAX];
-    char host[PATH_MAX];
-    char htcphost[PATH_MAX];
-    int htcpsock;
-    int tilesize;
-    double scale;
-    int minzoom;
-    int maxzoom;
-    int ok;
-    parameterize_function_ptr parameterize_function; 
-    xmlmapconfig() :
-        map(256,256) {}
+  char xmlname[XMLCONFIG_MAX];
+  char xmlfile[PATH_MAX];
+  struct storage_backend *store;
+  Map map;
+  struct projectionconfig *prj;
+  char xmluri[PATH_MAX];
+  char host[PATH_MAX];
+  char htcphost[PATH_MAX];
+  int htcpsock;
+  int tilesize;
+  double scale;
+  int minzoom;
+  int maxzoom;
+  int ok;
+  parameterize_function_ptr parameterize_function;
+  xmlmapconfig() : map(256, 256) {}
 };
 
+struct projectionconfig *get_projection(const char *srs) {
+  struct projectionconfig *prj;
 
-struct projectionconfig * get_projection(const char * srs) {
-    struct projectionconfig * prj;
+  if (strstr(srs, "+proj=merc +a=6378137 +b=6378137") != NULL) {
+    syslog(LOG_DEBUG, "DEBUG: Using web mercator projection settings");
+    prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
+    prj->bound_x0 = -20037508.3428;
+    prj->bound_x1 = 20037508.3428;
+    prj->bound_y0 = -20037508.3428;
+    prj->bound_y1 = 20037508.3428;
+    prj->aspect_x = 1;
+    prj->aspect_y = 1;
+  } else if (strcmp(srs, "+proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 "
+                         "+ellps=WGS84 +datum=WGS84 +units=m +no_defs") == 0) {
+    syslog(LOG_DEBUG, "DEBUG: Using plate carree projection settings");
+    prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
+    prj->bound_x0 = -20037508.3428;
+    prj->bound_x1 = 20037508.3428;
+    prj->bound_y0 = -10018754.1714;
+    prj->bound_y1 = 10018754.1714;
+    prj->aspect_x = 2;
+    prj->aspect_y = 1;
+  } else if (strcmp(
+                 srs,
+                 "+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 "
+                 "+y_0=-100000 +ellps=airy +datum=OSGB36 +units=m +no_defs") ==
+             0) {
+    syslog(LOG_DEBUG, "DEBUG: Using bng projection settings");
+    prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
+    prj->bound_x0 = 0;
+    prj->bound_y0 = 0;
+    prj->bound_x1 = 700000;
+    prj->bound_y1 = 1400000;
+    prj->aspect_x = 1;
+    prj->aspect_y = 2;
+  } else {
+    syslog(LOG_WARNING,
+           "WARNING: Unknown projection string, using web mercator as never "
+           "the less. %s\n",
+           srs);
+    prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
+    prj->bound_x0 = -20037508.3428;
+    prj->bound_x1 = 20037508.3428;
+    prj->bound_y0 = -20037508.3428;
+    prj->bound_y1 = 20037508.3428;
+    prj->aspect_x = 1;
+    prj->aspect_y = 1;
+  }
 
-    if (strstr(srs,"+proj=merc +a=6378137 +b=6378137") != NULL) {
-        syslog(LOG_DEBUG, "Using web mercator projection settings");
-        prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
-        prj->bound_x0 = -20037508.3428;
-        prj->bound_x1 =  20037508.3428;
-        prj->bound_y0 = -20037508.3428;
-        prj->bound_y1 =  20037508.3428;
-        prj->aspect_x = 1;
-        prj->aspect_y = 1;
-    } else if (strcmp(srs, "+proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs") == 0) {
-        syslog(LOG_DEBUG, "Using plate carree projection settings");
-        prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
-        prj->bound_x0 = -20037508.3428;
-        prj->bound_x1 =  20037508.3428;
-        prj->bound_y0 = -10018754.1714;
-        prj->bound_y1 =  10018754.1714;
-        prj->aspect_x = 2;
-        prj->aspect_y = 1;
-    } else if (strcmp(srs, "+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy +datum=OSGB36 +units=m +no_defs") == 0) {
-        syslog(LOG_DEBUG, "Using bng projection settings");
-        prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
-        prj->bound_x0 = 0;
-        prj->bound_y0 = 0;
-        prj->bound_x1 = 700000;
-        prj->bound_y1 = 1400000;
-        prj->aspect_x = 1;
-        prj->aspect_y = 2;
-    } else {
-        syslog(LOG_WARNING, "Unknown projection string, using web mercator as never the less. %s", srs);
-        prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
-        prj->bound_x0 = -20037508.3428;
-        prj->bound_x1 =  20037508.3428;
-        prj->bound_y0 = -20037508.3428;
-        prj->bound_y1 =  20037508.3428;
-        prj->aspect_x = 1;
-        prj->aspect_y = 1;
-    }
-
-    return prj;
+  return prj;
 }
 
-static void load_fonts(const char *font_dir, int recurse)
-{
-    DIR *fonts = opendir(font_dir);
-    struct dirent *entry;
-    char path[PATH_MAX]; // FIXME: Eats lots of stack space when recursive
+static void load_fonts(const char *font_dir, int recurse) {
+  DIR *fonts = opendir(font_dir);
+  struct dirent *entry;
+  char path[PATH_MAX]; // FIXME: Eats lots of stack space when recursive
 
-    if (!fonts) {
-        syslog(LOG_CRIT, "Unable to open font directory: %s", font_dir);
-        return;
+  if (!fonts) {
+    syslog(LOG_CRIT, "CRITICAL: Unable to open font directory: %s\n", font_dir);
+    return;
+  }
+
+  while ((entry = readdir(fonts))) {
+    struct stat b;
+    char *p;
+
+    if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+      continue;
+    snprintf(path, sizeof(path), "%s/%s", font_dir, entry->d_name);
+    if (stat(path, &b))
+      continue;
+    if (S_ISDIR(b.st_mode)) {
+      if (recurse)
+        load_fonts(path, recurse);
+      continue;
     }
-
-    while ((entry = readdir(fonts))) {
-        struct stat b;
-        char *p;
-
-        if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
-            continue;
-        snprintf(path, sizeof(path), "%s/%s", font_dir, entry->d_name);
-        if (stat(path, &b))
-            continue;
-        if (S_ISDIR(b.st_mode)) {
-            if (recurse)
-                load_fonts(path, recurse);
-            continue;
-        }
-        p = strrchr(path, '.');
-        if (p && (!strcmp(p, ".ttf") || !strcmp(p, ".otf") || !strcmp(p, ".ttc"))) {
-            syslog(LOG_DEBUG, "DEBUG: Loading font: %s", path);
-            freetype_engine::register_font(path);
-        }
+    p = strrchr(path, '.');
+    if (p && (!strcmp(p, ".ttf") || !strcmp(p, ".otf") || !strcmp(p, ".ttc"))) {
+      syslog(LOG_DEBUG, "DEBUG: Loading font: %s\n", path);
+      freetype_engine::register_font(path);
     }
-    closedir(fonts);
+  }
+  closedir(fonts);
 }
 
 /**
- * Set the connection pool size of mapnik's datasources  to correspond to the number of
- * rendering threads used in renderd
+ * Set the connection pool size of mapnik's datasources  to correspond to the
+ *number of rendering threads used in renderd
  **/
 static void parameterize_map_max_connections(Map &m, int num_threads) {
-    unsigned int i;
-    char * tmp = (char *)malloc(20);
-    for (i = 0; i < m.layer_count(); i++) {
+  unsigned int i;
+  char *tmp = (char *)malloc(20);
+  for (i = 0; i < m.layer_count(); i++) {
 #if MAPNIK_VERSION >= 300000
-        layer& l = m.get_layer(i);
+    layer &l = m.get_layer(i);
 #else
-        layer& l = m.getLayer(i);
+    layer &l = m.getLayer(i);
 #endif
-        parameters params = l.datasource()->params();
-        if (params.find("max_size") == params.end()) {
-            sprintf(tmp, "%i", num_threads + 2);
-            params["max_size"] = std::string(tmp);
-        }
-#if MAPNIK_VERSION >= 200200
-        l.set_datasource(datasource_cache::instance().create(params));
-#else
-        l.set_datasource(datasource_cache::instance()->create(params));
-#endif
+    parameters params = l.datasource()->params();
+    if (params.find("max_size") == params.end()) {
+      sprintf(tmp, "%i", num_threads + 2);
+      params["max_size"] = std::string(tmp);
     }
-    free(tmp);
+#if MAPNIK_VERSION >= 200200
+    l.set_datasource(datasource_cache::instance().create(params));
+#else
+    l.set_datasource(datasource_cache::instance()->create(params));
+#endif
+  }
+  free(tmp);
 }
 
+static int check_xyz(int x, int y, int z, struct xmlmapconfig *map) {
+  int oob, limit;
 
-static int check_xyz(int x, int y, int z, struct xmlmapconfig * map) {
-    int oob, limit;
+  // Validate tile co-ordinates
+  oob = (z < map->minzoom || z > map->maxzoom);
+  if (!oob) {
+    // valid x/y for tiles are 0 ... 2^zoom-1
+    limit = (1 << z);
+    oob = (x < 0 || x > (limit * map->prj->aspect_x - 1) || y < 0 ||
+           y > (limit * map->prj->aspect_y - 1));
+  }
 
-    // Validate tile co-ordinates
-    oob = (z < map->minzoom || z > map->maxzoom);
-    if (!oob) {
-         // valid x/y for tiles are 0 ... 2^zoom-1
-        limit = (1 << z);
-        oob =  (x < 0 || x > (limit * map->prj->aspect_x - 1) || y < 0 || y > (limit * map->prj->aspect_y - 1));
-    }
+  if (oob)
+    syslog(LOG_INFO, "INFO: got bad co-ords: x(%d) y(%d) z(%d)\n", x, y, z);
 
-    if (oob)
-        syslog(LOG_INFO, "got bad co-ords: x(%d) y(%d) z(%d)\n", x, y, z);
-
-    return !oob;
+  return !oob;
 }
 
 #ifdef METATILE
-mapnik::box2d<double> tile2prjbounds(struct projectionconfig * prj, int x, int y, int z) {
+mapnik::box2d<double> tile2prjbounds(struct projectionconfig *prj, int x, int y,
+                                     int z) {
 
-    int render_size_tx = MIN(METATILE, prj->aspect_x * (1 << z));
-    int render_size_ty = MIN(METATILE, prj->aspect_y * (1 << z));
+  int render_size_tx = MIN(METATILE, prj->aspect_x * (1 << z));
+  int render_size_ty = MIN(METATILE, prj->aspect_y * (1 << z));
 
-    double p0x = prj->bound_x0 + (prj->bound_x1 - prj->bound_x0)* ((double)x / (double)(prj->aspect_x * 1<<z));
-    double p0y = (prj->bound_y1 - (prj->bound_y1 - prj->bound_y0)* (((double)y + render_size_ty) / (double)(prj->aspect_y * 1<<z)));
-    double p1x = prj->bound_x0 + (prj->bound_x1 - prj->bound_x0)* (((double)x + render_size_tx) / (double)(prj->aspect_x * 1<<z));
-    double p1y = (prj->bound_y1 - (prj->bound_y1 - prj->bound_y0)* ((double)y / (double)(prj->aspect_y * 1<<z)));
+  double p0x =
+      prj->bound_x0 + (prj->bound_x1 - prj->bound_x0) *
+                          ((double)x / (double)(prj->aspect_x * 1 << z));
+  double p0y = (prj->bound_y1 - (prj->bound_y1 - prj->bound_y0) *
+                                    (((double)y + render_size_ty) /
+                                     (double)(prj->aspect_y * 1 << z)));
+  double p1x = prj->bound_x0 + (prj->bound_x1 - prj->bound_x0) *
+                                   (((double)x + render_size_tx) /
+                                    (double)(prj->aspect_x * 1 << z));
+  double p1y =
+      (prj->bound_y1 - (prj->bound_y1 - prj->bound_y0) *
+                           ((double)y / (double)(prj->aspect_y * 1 << z)));
 
-    syslog(LOG_DEBUG, "Rendering projected coordinates %i %i %i -> %f|%f %f|%f to a %i x %i tile\n", z, x, y, p0x, p0y, p1x, p1y, render_size_tx, render_size_ty);
+  syslog(LOG_DEBUG,
+         "DEBUG: Rendering projected coordinates %i %i %i -> %f|%f %f|%f to a "
+         "%i x %i "
+         "tile\n",
+         z, x, y, p0x, p0y, p1x, p1y, render_size_tx, render_size_ty);
 
-    mapnik::box2d<double> bbox(p0x, p0y, p1x,p1y);
-    return  bbox;
+  mapnik::box2d<double> bbox(p0x, p0y, p1x, p1y);
+  return bbox;
 }
 
-static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char *options, metaTile &tiles)
-{
-    unsigned int render_size_tx = MIN(METATILE, map->prj->aspect_x * (1 << z));
-    unsigned int render_size_ty = MIN(METATILE, map->prj->aspect_y * (1 << z));
+static enum protoCmd render(struct xmlmapconfig *map, int x, int y, int z,
+                            char *options, metaTile &tiles) {
+  unsigned int render_size_tx = MIN(METATILE, map->prj->aspect_x * (1 << z));
+  unsigned int render_size_ty = MIN(METATILE, map->prj->aspect_y * (1 << z));
 
-    map->map.resize(render_size_tx*map->tilesize, render_size_ty*map->tilesize);
-    map->map.zoom_to_box(tile2prjbounds(map->prj, x, y, z));
-    if (map->map.buffer_size() == 0) { // Only set buffer size if the buffer size isn't explicitly set in the mapnik stylesheet.
-        map->map.set_buffer_size((map->tilesize >> 1) * map->scale);
-    }
-    //m.zoom(size+1);
+  map->map.resize(render_size_tx * map->tilesize,
+                  render_size_ty * map->tilesize);
+  map->map.zoom_to_box(tile2prjbounds(map->prj, x, y, z));
+  if (map->map.buffer_size() ==
+      0) { // Only set buffer size if the buffer size isn't explicitly set in
+           // the mapnik stylesheet.
+    map->map.set_buffer_size((map->tilesize >> 1) * map->scale);
+  }
+  // m.zoom(size+1);
 
-    mapnik::image_32 buf(render_size_tx*map->tilesize, render_size_ty*map->tilesize);
-    try {
-        Map map_parameterized = map->map; 
-        if (map->parameterize_function) 
-            map->parameterize_function(map_parameterized, options); 
-        mapnik::agg_renderer<mapnik::image_32> ren(map_parameterized,buf,map->scale);
-        ren.apply();
-    } catch (std::exception const& ex) {
-      syslog(LOG_ERR, "ERROR: failed to render TILE %s %d %d-%d %d-%d", map->xmlname, z, x, x+render_size_tx-1, y, y+render_size_ty-1);
-      syslog(LOG_ERR, "   reason: %s", ex.what());
-      return cmdNotDone;
-    }
-
-    // Split the meta tile into an NxN grid of tiles
-    unsigned int xx, yy;
-    for (yy = 0; yy < render_size_ty; yy++) {
-        for (xx = 0; xx < render_size_tx; xx++) {
-#if MAPNIK_VERSION >= 300000
-            mapnik::image_view<mapnik::image<mapnik::rgba8_t>> vw1(xx * map->tilesize, yy * map->tilesize, map->tilesize, map->tilesize, buf);
-            struct mapnik::image_view_any vw(vw1);
-#else
-            mapnik::image_view<mapnik::image_data_32> vw(xx * map->tilesize, yy * map->tilesize, map->tilesize, map->tilesize, buf.data());
-#endif
-            tiles.set(xx, yy, save_to_string(vw, "png256"));
-        }
-    }
-    return cmdDone; // OK
-}
-#else //METATILE
-static enum protoCmd render(Map &m, const char *tile_dir, char *xmlname, projection &prj, int x, int y, int z)
-{
-    char filename[PATH_MAX];
-    char tmp[PATH_MAX];
-    double p0x = x * 256.0;
-    double p0y = (y + 1) * 256.0;
-    double p1x = (x + 1) * 256.0;
-    double p1y = y * 256.0;
-
-    tiling.fromPixelToLL(p0x, p0y, z);
-    tiling.fromPixelToLL(p1x, p1y, z);
-
-    prj.forward(p0x, p0y);
-    prj.forward(p1x, p1y);
-
-    mapnik::box2d<double> bbox(p0x, p0y, p1x,p1y);
-    bbox.width(bbox.width() * 2);
-    bbox.height(bbox.height() * 2);
-    m.zoomToBox(bbox);
-
-    mapnik::image_32 buf(RENDER_SIZE, RENDER_SIZE);
-    mapnik::agg_renderer<mapnik::image_32> ren(m,buf);
+  mapnik::image_32 buf(render_size_tx * map->tilesize,
+                       render_size_ty * map->tilesize);
+  try {
+    Map map_parameterized = map->map;
+    if (map->parameterize_function)
+      map->parameterize_function(map_parameterized, options);
+    mapnik::agg_renderer<mapnik::image_32> ren(map_parameterized, buf,
+                                               map->scale);
     ren.apply();
+  } catch (std::exception const &ex) {
+    syslog(LOG_ERR, "ERROR: failed to render TILE %s %d %d-%d %d-%d\n",
+           map->xmlname, z, x, x + render_size_tx - 1, y,
+           y + render_size_ty - 1);
+    syslog(LOG_ERR, "ERROR:    reason: %s\n", ex.what());
+    return cmdNotDone;
+  }
 
-    xyz_to_path(filename, sizeof(filename), tile_dir, xmlname, x, y, z);
-    if (mkdirp(filename))
-        return cmdNotDone;
-    snprintf(tmp, sizeof(tmp), "%s.tmp", filename);
-
-    mapnik::image_view<mapnik::image_data_32> vw(128, 128, 256, 256, buf.data());
-    //std::cout << "Render " << z << " " << x << " " << y << " " << filename << "\n";
-    mapnik::save_to_file(vw, tmp, "png256");
-    if (rename(tmp, filename)) {
-        perror(tmp);
-        return cmdNotDone;
-    }
-
-    return cmdDone; // OK
-}
-#endif //METATILE
-
-
-void render_init(const char *plugins_dir, const char* font_dir, int font_dir_recurse)
-{
-  syslog(LOG_INFO, "Renderd is using mapnik version %i.%i.%i", ((MAPNIK_VERSION) / 100000), (((MAPNIK_VERSION) / 100) % 1000), ((MAPNIK_VERSION) % 100));
-#if MAPNIK_VERSION >= 200200
-    mapnik::datasource_cache::instance().register_datasources(plugins_dir);
+  // Split the meta tile into an NxN grid of tiles
+  unsigned int xx, yy;
+  for (yy = 0; yy < render_size_ty; yy++) {
+    for (xx = 0; xx < render_size_tx; xx++) {
+#if MAPNIK_VERSION >= 300000
+      mapnik::image_view<mapnik::image<mapnik::rgba8_t>> vw1(
+          xx * map->tilesize, yy * map->tilesize, map->tilesize, map->tilesize,
+          buf);
+      struct mapnik::image_view_any vw(vw1);
 #else
-    mapnik::datasource_cache::instance()->register_datasources(plugins_dir);
+      mapnik::image_view<mapnik::image_data_32> vw(
+          xx * map->tilesize, yy * map->tilesize, map->tilesize, map->tilesize,
+          buf.data());
 #endif
-    load_fonts(font_dir, font_dir_recurse);
+      tiles.set(xx, yy, save_to_string(vw, "png256"));
+    }
+  }
+  return cmdDone; // OK
+}
+#else  // METATILE
+static enum protoCmd render(Map &m, const char *tile_dir, char *xmlname,
+                            projection &prj, int x, int y, int z) {
+  char filename[PATH_MAX];
+  char tmp[PATH_MAX];
+  double p0x = x * 256.0;
+  double p0y = (y + 1) * 256.0;
+  double p1x = (x + 1) * 256.0;
+  double p1y = y * 256.0;
+
+  tiling.fromPixelToLL(p0x, p0y, z);
+  tiling.fromPixelToLL(p1x, p1y, z);
+
+  prj.forward(p0x, p0y);
+  prj.forward(p1x, p1y);
+
+  mapnik::box2d<double> bbox(p0x, p0y, p1x, p1y);
+  bbox.width(bbox.width() * 2);
+  bbox.height(bbox.height() * 2);
+  m.zoomToBox(bbox);
+
+  mapnik::image_32 buf(RENDER_SIZE, RENDER_SIZE);
+  mapnik::agg_renderer<mapnik::image_32> ren(m, buf);
+  ren.apply();
+
+  xyz_to_path(filename, sizeof(filename), tile_dir, xmlname, x, y, z);
+  if (mkdirp(filename))
+    return cmdNotDone;
+  snprintf(tmp, sizeof(tmp), "%s.tmp", filename);
+
+  mapnik::image_view<mapnik::image_data_32> vw(128, 128, 256, 256, buf.data());
+  // std::cout << "Render " << z << " " << x << " " << y << " " << filename <<
+  // "\n";
+  mapnik::save_to_file(vw, tmp, "png256");
+  if (rename(tmp, filename)) {
+    perror(tmp);
+    return cmdNotDone;
+  }
+
+  return cmdDone; // OK
+}
+#endif // METATILE
+
+void render_init(const char *plugins_dir, const char *font_dir,
+                 int font_dir_recurse) {
+  syslog(LOG_INFO, "INFO: Renderd is using mapnik version %i.%i.%i\n",
+         ((MAPNIK_VERSION) / 100000), (((MAPNIK_VERSION) / 100) % 1000),
+         ((MAPNIK_VERSION) % 100));
+
+  if (log_priority >= 0) {
+    switch (log_priority) {
+    case (LOG_INFO):
+    case (LOG_WARNING):
+      mapnik::logger::instance().set_severity(mapnik::logger::warn);
+      break;
+    case (LOG_DEBUG):
+      mapnik::logger::instance().set_severity(mapnik::logger::debug);
+      break;
+    default:
+      mapnik::logger::instance().set_severity(mapnik::logger::error);
+      break;
+    }
+  }
+
+#if MAPNIK_VERSION >= 200200
+  mapnik::datasource_cache::instance().register_datasources(plugins_dir);
+#else
+  mapnik::datasource_cache::instance()->register_datasources(plugins_dir);
+#endif
+  load_fonts(font_dir, font_dir_recurse);
 }
 
-void *render_thread(void * arg)
-{
-    xmlconfigitem * parentxmlconfig = (xmlconfigitem *)arg;
-    xmlmapconfig maps[XMLCONFIGS_MAX];
-    int i,iMaxConfigs;
-    int render_time;
+void *render_thread(void *arg) {
+  xmlconfigitem *parentxmlconfig = (xmlconfigitem *)arg;
+  xmlmapconfig maps[XMLCONFIGS_MAX];
+  int i, iMaxConfigs;
+  int render_time;
 
-    for (iMaxConfigs = 0; iMaxConfigs < XMLCONFIGS_MAX; ++iMaxConfigs) {
-        if (parentxmlconfig[iMaxConfigs].xmlname[0] == 0 || parentxmlconfig[iMaxConfigs].xmlfile[0] == 0) break;
-        strcpy(maps[iMaxConfigs].xmlname, parentxmlconfig[iMaxConfigs].xmlname);
-        strcpy(maps[iMaxConfigs].xmlfile, parentxmlconfig[iMaxConfigs].xmlfile);
-        maps[iMaxConfigs].store = init_storage_backend(parentxmlconfig[iMaxConfigs].tile_dir);
-        maps[iMaxConfigs].tilesize  = parentxmlconfig[iMaxConfigs].tile_px_size;
-        maps[iMaxConfigs].scale  = parentxmlconfig[iMaxConfigs].scale_factor;
-        maps[iMaxConfigs].minzoom = parentxmlconfig[iMaxConfigs].min_zoom;
-        maps[iMaxConfigs].maxzoom = parentxmlconfig[iMaxConfigs].max_zoom;
-        maps[iMaxConfigs].parameterize_function = init_parameterization_function(parentxmlconfig[iMaxConfigs].parameterization);
+  for (iMaxConfigs = 0; iMaxConfigs < XMLCONFIGS_MAX; ++iMaxConfigs) {
+    if (parentxmlconfig[iMaxConfigs].xmlname[0] == 0 ||
+        parentxmlconfig[iMaxConfigs].xmlfile[0] == 0)
+      break;
+    strcpy(maps[iMaxConfigs].xmlname, parentxmlconfig[iMaxConfigs].xmlname);
+    strcpy(maps[iMaxConfigs].xmlfile, parentxmlconfig[iMaxConfigs].xmlfile);
+    maps[iMaxConfigs].store =
+        init_storage_backend(parentxmlconfig[iMaxConfigs].tile_dir);
+    maps[iMaxConfigs].tilesize = parentxmlconfig[iMaxConfigs].tile_px_size;
+    maps[iMaxConfigs].scale = parentxmlconfig[iMaxConfigs].scale_factor;
+    maps[iMaxConfigs].minzoom = parentxmlconfig[iMaxConfigs].min_zoom;
+    maps[iMaxConfigs].maxzoom = parentxmlconfig[iMaxConfigs].max_zoom;
+    maps[iMaxConfigs].parameterize_function = init_parameterization_function(
+        parentxmlconfig[iMaxConfigs].parameterization);
 
+    if (maps[iMaxConfigs].store) {
+      maps[iMaxConfigs].ok = 1;
 
-        if (maps[iMaxConfigs].store) {
-            maps[iMaxConfigs].ok = 1;
+      maps[iMaxConfigs].map.resize(RENDER_SIZE, RENDER_SIZE);
 
-            maps[iMaxConfigs].map.resize(RENDER_SIZE, RENDER_SIZE);
-
-            try {
-                mapnik::load_map(maps[iMaxConfigs].map, maps[iMaxConfigs].xmlfile);
-                /* If we have more than 10 rendering threads configured, we need to fix
-                 * up the mapnik datasources to support larger postgres connection pools
-                 */
-                if (parentxmlconfig[iMaxConfigs].num_threads > 10) {
-                    syslog(LOG_INFO, "Updating max_connection parameter for mapnik layers to reflect thread count");
-                    parameterize_map_max_connections(maps[iMaxConfigs].map, parentxmlconfig[iMaxConfigs].num_threads);
-                }
-                maps[iMaxConfigs].prj = get_projection(maps[iMaxConfigs].map.srs().c_str());
-            } catch (std::exception const& ex) {
-                syslog(LOG_ERR, "An error occurred while loading the map layer '%s': %s", maps[iMaxConfigs].xmlname, ex.what());
-                maps[iMaxConfigs].ok = 0;
-            } catch (...) {
-                syslog(LOG_ERR, "An unknown error occurred while loading the map layer '%s'", maps[iMaxConfigs].xmlname);
-                maps[iMaxConfigs].ok = 0;
-            }
-
-#ifdef HTCP_EXPIRE_CACHE
-            strcpy(maps[iMaxConfigs].xmluri, parentxmlconfig[iMaxConfigs].xmluri);
-            strcpy(maps[iMaxConfigs].host, parentxmlconfig[iMaxConfigs].host);
-            strcpy(maps[iMaxConfigs].htcphost, parentxmlconfig[iMaxConfigs].htcpip);
-            if (strlen(maps[iMaxConfigs].htcphost) > 0) {
-                maps[iMaxConfigs].htcpsock = init_cache_expire(
-                        maps[iMaxConfigs].htcphost);
-                if (maps[iMaxConfigs].htcpsock > 0) {
-                    syslog(LOG_INFO, "Successfully opened socket for HTCP cache expiry");
-                } else {
-                    syslog(LOG_ERR, "Failed to opened socket for HTCP cache expiry");
-                }
-            } else {
-                maps[iMaxConfigs].htcpsock = -1;
-            }
-
-#endif
-        } else
-            maps[iMaxConfigs].ok = 0;
-    }
-
-    while (1) {
-        enum protoCmd ret;
-        struct item *item = request_queue_fetch_request(render_request_queue);
-        render_time = -1;
-        if (item) {
-            struct protocol *req = &item->req;
-#ifdef METATILE
-            // At very low zoom the whole world may be smaller than METATILE
-            unsigned int size = MIN(METATILE, 1 << req->z);
-            for (i = 0; i < iMaxConfigs; ++i) {
-                if (!strcmp(maps[i].xmlname, req->xmlname)) {
-                    if (maps[i].ok) {
-                        if (check_xyz(item->mx, item->my, req->z, &(maps[i]))) {
-
-                            metaTile tiles(req->xmlname, req->options, item->mx, item->my, req->z);
-
-                            timeval tim;
-                            gettimeofday(&tim, NULL);
-                            long t1=tim.tv_sec*1000+(tim.tv_usec/1000);
-
-                            struct stat_info sinfo = maps[i].store->tile_stat(maps[i].store, req->xmlname, req->options, item->mx, item->my, req->z);
-
-                            if(sinfo.size > 0)
-                                syslog(LOG_DEBUG, "DEBUG: START TILE %s %d %d-%d %d-%d, age %.2f days",
-                                       req->xmlname, req->z, item->mx, item->mx+size-1, item->my, item->my+size-1,
-                                       (tim.tv_sec-sinfo.mtime)/86400.0);
-                            else
-                                syslog(LOG_DEBUG, "DEBUG: START TILE %s %d %d-%d %d-%d, new metatile",
-                                       req->xmlname, req->z, item->mx, item->mx+size-1, item->my, item->my+size-1);
-
-                            ret = render(&(maps[i]), item->mx, item->my, req->z, req->options, tiles);
-
-                            gettimeofday(&tim, NULL);
-                            long t2=tim.tv_sec*1000+(tim.tv_usec/1000);
-
-                            syslog(LOG_DEBUG, "DEBUG: DONE TILE %s %d %d-%d %d-%d in %.3lf seconds",
-                                    req->xmlname, req->z, item->mx, item->mx+size-1, item->my, item->my+size-1, (t2 - t1)/1000.0);
-
-                            render_time = t2 - t1;
-
-                            if (ret == cmdDone) {
-                                try {
-                                    tiles.save(maps[i].store);
-#ifdef HTCP_EXPIRE_CACHE
-                                    tiles.expire_tiles(maps[i].htcpsock,maps[i].host,maps[i].xmluri);
-#endif
-
-                                } catch (std::exception const& ex) {
-                                    syslog(LOG_ERR, "Received exception when writing metatile to disk: %s", ex.what());
-                                    ret = cmdNotDone;
-                                } catch (...) {
-                                    // Treat any error as fatal and request end of processing
-                                    syslog(LOG_ERR, "Failed writing metatile to disk with unknown error, requesting exit.");
-                                    ret = cmdNotDone;
-                                    request_exit();
-                                }
-                            }
-#else //METATILE
-                        ret = render(maps[i].map, maps[i].tile_dir, req->xmlname, maps[i].prj, req->x, req->y, req->z);
-#ifdef HTCP_EXPIRE_CACHE
-                        cache_expire(maps[i].htcpsock,maps[i].host, maps[i].xmluri, req->x,req->y,req->z);
-#endif
-#endif //METATILE
-                        } else {
-                            syslog(LOG_WARNING, "Received request for map layer %s is outside of acceptable bounds z(%i), x(%i), y(%i)",
-                                    req->xmlname, req->z, req->x, req->y);
-                            ret = cmdIgnore;
-                        }
-                    } else {
-                        syslog(LOG_ERR, "Received request for map layer '%s' which failed to load", req->xmlname);
-                        ret = cmdNotDone;
-                    }
-                    send_response(item, ret, render_time);
-                    if ((ret != cmdDone) && (ret != cmdIgnore)) sleep(10); //Something went wrong with rendering, delay next processing to allow temporary issues to fix them selves
-                    break;
-               }
-            }
-            if (i == iMaxConfigs){
-                syslog(LOG_ERR, "No map for: %s", req->xmlname);
-            }
-        } else {
-            sleep(1); // TODO: Use an event to indicate there are new requests
+      try {
+        mapnik::load_map(maps[iMaxConfigs].map, maps[iMaxConfigs].xmlfile);
+        /* If we have more than 10 rendering threads configured, we need to fix
+         * up the mapnik datasources to support larger postgres connection pools
+         */
+        if (parentxmlconfig[iMaxConfigs].num_threads > 10) {
+          syslog(LOG_INFO, "INFO: Updating max_connection parameter for mapnik "
+                           "layers to reflect thread count");
+          parameterize_map_max_connections(
+              maps[iMaxConfigs].map, parentxmlconfig[iMaxConfigs].num_threads);
         }
-    }
-    return NULL;
-}
+        maps[iMaxConfigs].prj =
+            get_projection(maps[iMaxConfigs].map.srs().c_str());
+      } catch (std::exception const &ex) {
+        syslog(
+            LOG_ERR,
+            "ERROR: An error occurred while loading the map layer '%s': %s\n",
+            maps[iMaxConfigs].xmlname, ex.what());
+        maps[iMaxConfigs].ok = 0;
+      } catch (...) {
+        syslog(
+            LOG_ERR,
+            "ERROR: An unknown error occurred while loading the map layer '%s'",
+            maps[iMaxConfigs].xmlname);
+        maps[iMaxConfigs].ok = 0;
+      }
 
+#ifdef HTCP_EXPIRE_CACHE
+      strcpy(maps[iMaxConfigs].xmluri, parentxmlconfig[iMaxConfigs].xmluri);
+      strcpy(maps[iMaxConfigs].host, parentxmlconfig[iMaxConfigs].host);
+      strcpy(maps[iMaxConfigs].htcphost, parentxmlconfig[iMaxConfigs].htcpip);
+      if (strlen(maps[iMaxConfigs].htcphost) > 0) {
+        maps[iMaxConfigs].htcpsock =
+            init_cache_expire(maps[iMaxConfigs].htcphost);
+        if (maps[iMaxConfigs].htcpsock > 0) {
+          syslog(LOG_INFO,
+                 "INFO: Successfully opened socket for HTCP cache expiry");
+        } else {
+          syslog(LOG_ERR,
+                 "ERROR: Failed to opened socket for HTCP cache expiry");
+        }
+      } else {
+        maps[iMaxConfigs].htcpsock = -1;
+      }
+
+#endif
+    } else
+      maps[iMaxConfigs].ok = 0;
+  }
+
+  while (1) {
+    enum protoCmd ret;
+    struct item *item = request_queue_fetch_request(render_request_queue);
+    render_time = -1;
+    if (item) {
+      struct protocol *req = &item->req;
+#ifdef METATILE
+      // At very low zoom the whole world may be smaller than METATILE
+      unsigned int size = MIN(METATILE, 1 << req->z);
+      for (i = 0; i < iMaxConfigs; ++i) {
+        if (!strcmp(maps[i].xmlname, req->xmlname)) {
+          if (maps[i].ok) {
+            if (check_xyz(item->mx, item->my, req->z, &(maps[i]))) {
+
+              metaTile tiles(req->xmlname, req->options, item->mx, item->my,
+                             req->z);
+
+              timeval tim;
+              gettimeofday(&tim, NULL);
+              long t1 = tim.tv_sec * 1000 + (tim.tv_usec / 1000);
+
+              struct stat_info sinfo = maps[i].store->tile_stat(
+                  maps[i].store, req->xmlname, req->options, item->mx, item->my,
+                  req->z);
+
+              if (sinfo.size > 0)
+                syslog(LOG_DEBUG,
+                       "DEBUG: START TILE %s %d %d-%d %d-%d, age %.2f days",
+                       req->xmlname, req->z, item->mx, item->mx + size - 1,
+                       item->my, item->my + size - 1,
+                       (tim.tv_sec - sinfo.mtime) / 86400.0);
+              else
+                syslog(LOG_DEBUG,
+                       "DEBUG: START TILE %s %d %d-%d %d-%d, new metatile",
+                       req->xmlname, req->z, item->mx, item->mx + size - 1,
+                       item->my, item->my + size - 1);
+
+              ret = render(&(maps[i]), item->mx, item->my, req->z, req->options,
+                           tiles);
+
+              gettimeofday(&tim, NULL);
+              long t2 = tim.tv_sec * 1000 + (tim.tv_usec / 1000);
+
+              syslog(LOG_DEBUG,
+                     "DEBUG: DONE TILE %s %d %d-%d %d-%d in %.3lf seconds",
+                     req->xmlname, req->z, item->mx, item->mx + size - 1,
+                     item->my, item->my + size - 1, (t2 - t1) / 1000.0);
+
+              render_time = t2 - t1;
+
+              if (ret == cmdDone) {
+                try {
+                  tiles.save(maps[i].store);
+#ifdef HTCP_EXPIRE_CACHE
+                  tiles.expire_tiles(maps[i].htcpsock, maps[i].host,
+                                     maps[i].xmluri);
+#endif
+
+                } catch (std::exception const &ex) {
+                  syslog(LOG_ERR,
+                         "ERROR: Received exception when writing metatile to "
+                         "disk: %s\n",
+                         ex.what());
+                  ret = cmdNotDone;
+                } catch (...) {
+                  // Treat any error as fatal and request end of processing
+                  syslog(LOG_ERR, "ERROR: Failed writing metatile to disk with "
+                                  "unknown error, requesting exit.");
+                  ret = cmdNotDone;
+                  request_exit();
+                }
+              }
+#else // METATILE
+      ret = render(maps[i].map, maps[i].tile_dir, req->xmlname, maps[i].prj,
+                   req->x, req->y, req->z);
+#ifdef HTCP_EXPIRE_CACHE
+      cache_expire(maps[i].htcpsock, maps[i].host, maps[i].xmluri, req->x,
+                   req->y, req->z);
+#endif
+#endif // METATILE
+            } else {
+              syslog(LOG_WARNING,
+                     "WARNING: Received request for map layer %s is outside of "
+                     "acceptable bounds z(%i), x(%i), y(%i)",
+                     req->xmlname, req->z, req->x, req->y);
+              ret = cmdIgnore;
+            }
+          } else {
+            syslog(LOG_ERR,
+                   "ERROR: Received request for map layer '%s' which failed to "
+                   "load",
+                   req->xmlname);
+            ret = cmdNotDone;
+          }
+          send_response(item, ret, render_time);
+          if ((ret != cmdDone) && (ret != cmdIgnore))
+            sleep(
+                10); // Something went wrong with rendering, delay next
+                     // processing to allow temporary issues to fix them selves
+          break;
+        }
+      }
+      if (i == iMaxConfigs) {
+        syslog(LOG_ERR, "ERROR: No map for: %s\n", req->xmlname);
+      }
+    } else {
+      sleep(1); // TODO: Use an event to indicate there are new requests
+    }
+  }
+  return NULL;
+}

--- a/src/parameterize_style.cpp
+++ b/src/parameterize_style.cpp
@@ -1,9 +1,9 @@
-#include <mapnik/version.hpp>
-#include <mapnik/map.hpp>
-#include <mapnik/layer.hpp>
-#include <mapnik/params.hpp>
 #include <mapnik/datasource.hpp>
 #include <mapnik/datasource_cache.hpp>
+#include <mapnik/layer.hpp>
+#include <mapnik/map.hpp>
+#include <mapnik/params.hpp>
+#include <mapnik/version.hpp>
 
 #include <syslog.h>
 
@@ -11,66 +11,66 @@
 
 #include "parameterize_style.hpp"
 
+static void parameterize_map_language(mapnik::Map &m, char *parameter) {
+  unsigned int i;
+  char *data = strdup(parameter);
+  char *tok;
+  char name_replace[256];
 
-static void parameterize_map_language(mapnik::Map &m, char * parameter) { 
-    unsigned int i;
-    char * data = strdup(parameter); 
-    char * tok; 
-    char name_replace[256]; 
-    
-    name_replace[0] = 0; 
-    syslog(LOG_DEBUG, "Internationalizing map to language parameter: %s", parameter); 
-    tok = strtok(data,","); 
-    if (!tok) return; //No parameterization given 
-    strncat(name_replace, ", coalesce(", 255); 
-    while (tok) { 
-        if (strcmp(tok,"_") == 0) { 
-            strncat(name_replace,"name,", 255); 
-        } else { 
-            strncat(name_replace,"tags->'name:", 255); 
-            strncat(name_replace, tok, 255); 
-            strncat(name_replace,"',", 255); 
-        } 
-        tok = strtok(NULL, ","); 
-        
-    }
-    free(data);
-    name_replace[strlen(name_replace) - 1] = 0; 
-    strncat(name_replace,") as name", 255); 
-    for (i = 0; i < m.layer_count(); i++) { 
-#if MAPNIK_VERSION >= 300000
-        mapnik::layer& l = m.get_layer(i);
-#else
-        mapnik::layer& l = m.getLayer(i);
-#endif
-        mapnik::parameters params = l.datasource()->params(); 
-        if (params.find("table") != params.end()) {
-            boost::optional<std::string> table = params.get<std::string>("table");
-            if (table && table->find(",name") != std::string::npos) {
-                std::string str = *table;
-                size_t pos = str.find(",name"); 
-                str.replace(pos,5,name_replace); 
-                params["table"] = str; 
-#if MAPNIK_VERSION >= 200200
-                l.set_datasource(mapnik::datasource_cache::instance().create(params));
-#else
-                l.set_datasource(mapnik::datasource_cache::instance()->create(params));
-#endif
-            } 
-        } 
-        
-    } 
-}
-  
-
-parameterize_function_ptr init_parameterization_function(char * function_name) {
-    syslog(LOG_INFO, "Loading parameterization function for %s", function_name);
-    if (strcmp(function_name, "") == 0) {
-        return NULL;
-    } else if (strcmp(function_name, "language") == 0) {
-        return parameterize_map_language;
+  name_replace[0] = 0;
+  syslog(LOG_DEBUG, "DEBUG: Internationalizing map to language parameter: %s\n",
+         parameter);
+  tok = strtok(data, ",");
+  if (!tok)
+    return; // No parameterization given
+  strncat(name_replace, ", coalesce(", 255);
+  while (tok) {
+    if (strcmp(tok, "_") == 0) {
+      strncat(name_replace, "name,", 255);
     } else {
-        syslog(LOG_INFO, "WARNING: unknown parameterization function for %s", function_name);
+      strncat(name_replace, "tags->'name:", 255);
+      strncat(name_replace, tok, 255);
+      strncat(name_replace, "',", 255);
     }
+    tok = strtok(NULL, ",");
+  }
+  free(data);
+  name_replace[strlen(name_replace) - 1] = 0;
+  strncat(name_replace, ") as name", 255);
+  for (i = 0; i < m.layer_count(); i++) {
+#if MAPNIK_VERSION >= 300000
+    mapnik::layer &l = m.get_layer(i);
+#else
+    mapnik::layer &l = m.getLayer(i);
+#endif
+    mapnik::parameters params = l.datasource()->params();
+    if (params.find("table") != params.end()) {
+      boost::optional<std::string> table = params.get<std::string>("table");
+      if (table && table->find(",name") != std::string::npos) {
+        std::string str = *table;
+        size_t pos = str.find(",name");
+        str.replace(pos, 5, name_replace);
+        params["table"] = str;
+#if MAPNIK_VERSION >= 200200
+        l.set_datasource(mapnik::datasource_cache::instance().create(params));
+#else
+        l.set_datasource(mapnik::datasource_cache::instance()->create(params));
+#endif
+      }
+    }
+  }
+}
+
+parameterize_function_ptr init_parameterization_function(char *function_name) {
+  syslog(LOG_INFO, "INFO: Loading parameterization function for %s\n",
+         function_name);
+  if (strcmp(function_name, "") == 0) {
     return NULL;
+  } else if (strcmp(function_name, "language") == 0) {
+    return parameterize_map_language;
+  } else {
+    syslog(LOG_WARNING, "WARNING: unknown parameterization function for %s\n",
+           function_name);
+  }
+  return NULL;
 }

--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -91,6 +91,8 @@ static int maxZoom = 18;
 static int verbose = 0;
 static int maxLoad = MAX_LOAD_OLD;
 
+int log_priority = -1;
+
 void display_rate(struct timeval start, struct timeval end, int num) 
 {
     int d_s, d_us;

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -40,6 +40,8 @@ static int maxZoom = MAX_ZOOM;
 static int verbose = 0;
 static int maxLoad = MAX_LOAD_OLD;
 
+int log_priority = -1;
+
 void display_rate(struct timeval start, struct timeval end, int num) 
 {
     int d_s, d_us;

--- a/src/store.c
+++ b/src/store.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <syslog.h>
 #include <unistd.h>
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
@@ -22,6 +23,8 @@
 #include "store_ro_composite.h"
 #include "store_ro_http_proxy.h"
 
+extern int log_priority;
+
 // TODO: Make this function handle different logging backends, depending on if
 // on compiles it from apache or something else
 void log_message(int log_lvl, const char *format, ...) {
@@ -30,24 +33,41 @@ void log_message(int log_lvl, const char *format, ...) {
 
   va_start(ap, format);
 
-  if (msg) {
+  if (msg && strlen(msg) > 0) {
     vsnprintf(msg, 1000, format, ap);
-    switch (log_lvl) {
-    case STORE_LOGLVL_DEBUG:
-      fprintf(stderr, "debug: %s\n", msg);
-      break;
-    case STORE_LOGLVL_INFO:
-      fprintf(stderr, "info: %s\n", msg);
-      break;
-    case STORE_LOGLVL_WARNING:
-      fprintf(stderr, "WARNING: %s\n", msg);
-      break;
-    case STORE_LOGLVL_ERR:
-      fprintf(stderr, "ERROR: %s\n", msg);
-      break;
+    if (log_priority >= 0) {
+      switch (log_lvl) {
+      case STORE_LOGLVL_DEBUG:
+        syslog(LOG_DEBUG, "DEBUG: %s\n", msg);
+        break;
+      case STORE_LOGLVL_INFO:
+        syslog(LOG_INFO, "INFO: %s\n", msg);
+        break;
+      case STORE_LOGLVL_WARNING:
+        syslog(LOG_WARNING, "WARNING: %s\n", msg);
+        break;
+      case STORE_LOGLVL_ERR:
+        syslog(LOG_ERR, "ERROR: %s\n", msg);
+        break;
+      }
+    } else {
+      switch (log_lvl) {
+      case STORE_LOGLVL_DEBUG:
+        fprintf(stderr, "debug: %s\n", msg);
+        break;
+      case STORE_LOGLVL_INFO:
+        fprintf(stderr, "info: %s\n", msg);
+        break;
+      case STORE_LOGLVL_WARNING:
+        fprintf(stderr, "WARNING: %s\n", msg);
+        break;
+      case STORE_LOGLVL_ERR:
+        fprintf(stderr, "ERROR: %s\n", msg);
+        break;
+      }
+      fflush(stderr);
     }
     free(msg);
-    fflush(stderr);
   }
   va_end(ap);
 }

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -6,314 +6,280 @@
  * utilisation of disk space.
  */
 
-#include <assert.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <limits.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <utime.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <errno.h>
+#include <pthread.h>
 
-#include "metatile.h"
-#include "protocol.h"
-#include "render_config.h"
 #include "store.h"
+#include "metatile.h"
+#include "render_config.h"
 #include "store_file.h"
 #include "store_file_utils.h"
+#include "protocol.h"
 
-static time_t getPlanetTime(const char *tile_dir, const char *xmlname) {
-  struct stat st_stat;
-  char filename[PATH_MAX];
 
-  snprintf(filename, PATH_MAX - 1, "%s/%s%s", tile_dir, xmlname,
-           PLANET_TIMESTAMP);
+static time_t getPlanetTime(const char * tile_dir, const char * xmlname)
+{
+    struct stat st_stat;
+    char filename[PATH_MAX];
 
-  if (stat(filename, &st_stat) < 0) {
-    snprintf(filename, PATH_MAX - 1, "%s/%s", tile_dir, PLANET_TIMESTAMP);
+    snprintf(filename, PATH_MAX-1, "%s/%s%s", tile_dir, xmlname, PLANET_TIMESTAMP);
+
     if (stat(filename, &st_stat) < 0) {
-      // Make something up
-      return time(NULL) - (3 * 24 * 60 * 60);
+        snprintf(filename, PATH_MAX-1, "%s/%s", tile_dir, PLANET_TIMESTAMP);
+        if (stat(filename, &st_stat) < 0) {
+            // Make something up
+            return time(NULL) - (3*24*60*60);
+        }
     }
-  }
-  return st_stat.st_mtime;
+    return st_stat.st_mtime;
 }
 
-static int file_tile_read(struct storage_backend *store, const char *xmlconfig,
-                          const char *options, int x, int y, int z, char *buf,
-                          size_t sz, int *compressed, char *log_msg) {
+static int file_tile_read(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg) {
 
-  char path[PATH_MAX];
-  int meta_offset, fd;
-  unsigned int pos;
-  unsigned int header_len =
-      sizeof(struct meta_layout) + METATILE * METATILE * sizeof(struct entry);
-  struct meta_layout *m = (struct meta_layout *)malloc(header_len);
-  size_t file_offset, tile_size;
+    char path[PATH_MAX];
+    int meta_offset, fd;
+    unsigned int pos;
+    unsigned int header_len = sizeof(struct meta_layout) + METATILE*METATILE*sizeof(struct entry);
+    struct meta_layout *m = (struct meta_layout *)malloc(header_len);
+    size_t file_offset, tile_size;
 
-  meta_offset = xyzo_to_meta(path, sizeof(path), store->storage_ctx, xmlconfig,
-                             options, x, y, z);
+    meta_offset = xyzo_to_meta(path, sizeof(path), store->storage_ctx, xmlconfig, options, x, y, z);
 
-  fd = open(path, O_RDONLY);
-  if (fd < 0) {
-    snprintf(log_msg, PATH_MAX - 1, "Could not open metatile %s. Reason: %s\n",
-             path, strerror(errno));
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        snprintf(log_msg,PATH_MAX - 1, "Could not open metatile %s. Reason: %s\n", path, strerror(errno));
+        free(m);
+        return -1;
+    }
+
+    pos = 0;
+    while (pos < header_len) {
+        size_t len = header_len - pos;
+        int got = read(fd, ((unsigned char *) m) + pos, len);
+        if (got < 0) {
+            snprintf(log_msg,PATH_MAX - 1, "Failed to read complete header for metatile %s Reason: %s\n", path, strerror(errno));
+            close(fd);
+            free(m);
+            return -2;
+        } else if (got > 0) {
+            pos += got;
+        } else {
+            break;
+        }
+    }
+    if (pos < header_len) {
+        snprintf(log_msg,PATH_MAX - 1, "Meta file %s too small to contain header\n", path);
+        close(fd);
+        free(m);
+        return -3;
+    }
+    if (memcmp(m->magic, META_MAGIC, strlen(META_MAGIC))) {
+        if (memcmp(m->magic, META_MAGIC_COMPRESSED, strlen(META_MAGIC_COMPRESSED))) {
+            snprintf(log_msg,PATH_MAX - 1, "Meta file %s header magic mismatch\n", path);
+            close(fd);
+            free(m);
+            return -4;
+        } else {
+            *compressed = 1;
+        }
+    } else *compressed = 0;
+
+    // Currently this code only works with fixed metatile sizes (due to xyz_to_meta above)
+    if (m->count != (METATILE * METATILE)) {
+        snprintf(log_msg, PATH_MAX - 1, "Meta file %s header bad count %d != %d\n", path, m->count, METATILE * METATILE);
+        free(m);
+        close(fd);
+        return -5;
+    }
+
+    file_offset = m->index[meta_offset].offset;
+    tile_size   = m->index[meta_offset].size;
+
     free(m);
-    return -1;
-  }
 
-  pos = 0;
-  while (pos < header_len) {
-    size_t len = header_len - pos;
-    int got = read(fd, ((unsigned char *)m) + pos, len);
-    if (got < 0) {
-      snprintf(log_msg, PATH_MAX - 1,
-               "Failed to read complete header for metatile %s Reason: %s\n",
-               path, strerror(errno));
-      close(fd);
-      free(m);
-      return -2;
-    } else if (got > 0) {
-      pos += got;
-    } else {
-      break;
+    if (tile_size > sz) {
+        snprintf(log_msg, PATH_MAX - 1, "Truncating tile %zd to fit buffer of %zd\n", tile_size, sz);
+        tile_size = sz;
+        close(fd);
+        return -6;
     }
-  }
-  if (pos < header_len) {
-    snprintf(log_msg, PATH_MAX - 1,
-             "Meta file %s too small to contain header\n", path);
-    close(fd);
-    free(m);
-    return -3;
-  }
-  if (memcmp(m->magic, META_MAGIC, strlen(META_MAGIC))) {
-    if (memcmp(m->magic, META_MAGIC_COMPRESSED,
-               strlen(META_MAGIC_COMPRESSED))) {
-      snprintf(log_msg, PATH_MAX - 1, "Meta file %s header magic mismatch\n",
-               path);
-      close(fd);
-      free(m);
-      return -4;
-    } else {
-      *compressed = 1;
+
+    if (lseek(fd, file_offset, SEEK_SET) < 0) {
+        snprintf(log_msg, PATH_MAX - 1, "Meta file %s seek error: %s\n", path, strerror(errno));
+        close(fd);
+        return -7;
     }
-  } else
-    *compressed = 0;
-
-  // Currently this code only works with fixed metatile sizes (due to
-  // xyz_to_meta above)
-  if (m->count != (METATILE * METATILE)) {
-    snprintf(log_msg, PATH_MAX - 1, "Meta file %s header bad count %d != %d\n",
-             path, m->count, METATILE * METATILE);
-    free(m);
-    close(fd);
-    return -5;
-  }
-
-  file_offset = m->index[meta_offset].offset;
-  tile_size = m->index[meta_offset].size;
-
-  free(m);
-
-  if (tile_size > sz) {
-    snprintf(log_msg, PATH_MAX - 1,
-             "Truncating tile %zd to fit buffer of %zd\n", tile_size, sz);
-    tile_size = sz;
-    close(fd);
-    return -6;
-  }
-
-  if (lseek(fd, file_offset, SEEK_SET) < 0) {
-    snprintf(log_msg, PATH_MAX - 1, "Meta file %s seek error: %s\n", path,
-             strerror(errno));
-    close(fd);
-    return -7;
-  }
-
-  pos = 0;
-  while (pos < tile_size) {
-    size_t len = tile_size - pos;
-    int got = read(fd, buf + pos, len);
-    if (got < 0) {
-      snprintf(log_msg, PATH_MAX - 1,
-               "Failed to read data from file %s. Reason: %s\n", path,
-               strerror(errno));
-      close(fd);
-      return -8;
-    } else if (got > 0) {
-      pos += got;
-    } else {
-      break;
+    
+    pos = 0;
+    while (pos < tile_size) {
+        size_t len = tile_size - pos;
+        int got = read(fd, buf + pos, len);
+        if (got < 0) {
+            snprintf(log_msg, PATH_MAX - 1, "Failed to read data from file %s. Reason: %s\n", path, strerror(errno));
+            close(fd);
+            return -8;
+        } else if (got > 0) {
+            pos += got;
+        } else {
+            break;
+        }
     }
-  }
-  close(fd);
-  return pos;
+    close(fd);
+    return pos;
 }
 
-static struct stat_info file_tile_stat(struct storage_backend *store,
-                                       const char *xmlconfig,
-                                       const char *options, int x, int y,
-                                       int z) {
-  struct stat_info tile_stat;
-  struct stat st_stat;
-  char meta_path[PATH_MAX];
+static struct stat_info file_tile_stat(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z) {
+    struct stat_info tile_stat;
+    struct stat st_stat;
+    char meta_path[PATH_MAX];
 
-  xyzo_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx),
-               xmlconfig, options, x, y, z);
+    xyzo_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx), xmlconfig, options, x, y, z);
+    
+    if (stat(meta_path, &st_stat)) {
+        tile_stat.size = -1;
+        tile_stat.mtime = 0;
+        tile_stat.atime = 0;
+        tile_stat.ctime = 0;
+    } else {
+        tile_stat.size = st_stat.st_size;
+        tile_stat.mtime = st_stat.st_mtime;
+        tile_stat.atime = st_stat.st_atime;
+        tile_stat.ctime = st_stat.st_ctime;
+    }
 
-  if (stat(meta_path, &st_stat)) {
-    tile_stat.size = -1;
-    tile_stat.mtime = 0;
-    tile_stat.atime = 0;
-    tile_stat.ctime = 0;
-  } else {
-    tile_stat.size = st_stat.st_size;
-    tile_stat.mtime = st_stat.st_mtime;
-    tile_stat.atime = st_stat.st_atime;
-    tile_stat.ctime = st_stat.st_ctime;
-  }
+    if (tile_stat.mtime < getPlanetTime(store->storage_ctx, xmlconfig)) {
+        tile_stat.expired = 1;
+    } else {
+        tile_stat.expired = 0;
+    }
 
-  if (tile_stat.mtime < getPlanetTime(store->storage_ctx, xmlconfig)) {
-    tile_stat.expired = 1;
-  } else {
-    tile_stat.expired = 0;
-  }
-
-  return tile_stat;
+    return tile_stat;
 }
 
-static char *file_tile_storage_id(struct storage_backend *store,
-                                  const char *xmlconfig, const char *options,
-                                  int x, int y, int z, char *string) {
-  char meta_path[PATH_MAX];
+static char * file_tile_storage_id(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string) {
+    char meta_path[PATH_MAX];
 
-  xyzo_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx),
-               xmlconfig, options, x, y, z);
-  snprintf(string, PATH_MAX - 1, "file://%s", meta_path);
-  return string;
+    xyzo_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx), xmlconfig, options, x, y, z);
+    snprintf(string, PATH_MAX - 1, "file://%s", meta_path);
+    return string;
 }
+    
 
-static int file_metatile_write(struct storage_backend *store,
-                               const char *xmlconfig, const char *options,
-                               int x, int y, int z, const char *buf, int sz) {
-  int fd;
-  char meta_path[PATH_MAX];
-  char *tmp;
-  int res;
+static int file_metatile_write(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz) {
+    int fd;
+    char meta_path[PATH_MAX];
+    char * tmp;
+    int res;
+ 
+    xyzo_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx), xmlconfig, options, x, y, z);
+    log_message(STORE_LOGLVL_DEBUG, "Creating and writing a metatile to %s\n", meta_path);
 
-  xyzo_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx),
-               xmlconfig, options, x, y, z);
-  log_message(STORE_LOGLVL_DEBUG, "Creating and writing a metatile to %s\n",
-              meta_path);
+    tmp = malloc(sizeof(char) * strlen(meta_path) + 24);
+    snprintf(tmp, strlen(meta_path) + 24, "%s.%lu", meta_path, pthread_self());
 
-  tmp = malloc(sizeof(char) * strlen(meta_path) + 24);
-  snprintf(tmp, strlen(meta_path) + 24, "%s.%lu", meta_path, pthread_self());
+    if (mkdirp(tmp)) {
+        free(tmp);
+        return -1;
+    }
 
-  if (mkdirp(tmp)) {
+
+    fd = open(tmp, O_WRONLY | O_TRUNC | O_CREAT, 0666);
+    if (fd < 0) {
+        log_message(STORE_LOGLVL_WARNING, "Error creating file %s: %s\n", meta_path, strerror(errno));
+        free(tmp);
+        return -1;
+    }
+    
+    res = write(fd, buf, sz);
+    if (res != sz) {
+        log_message(STORE_LOGLVL_WARNING, "Error writing file %s: %s\n", meta_path, strerror(errno));
+        close(fd);
+        free(tmp);
+        return -1;
+    }
+
+    close(fd);
+    rename(tmp, meta_path);
     free(tmp);
-    return -1;
-  }
 
-  fd = open(tmp, O_WRONLY | O_TRUNC | O_CREAT, 0666);
-  if (fd < 0) {
-    log_message(STORE_LOGLVL_WARNING, "Error creating file %s: %s\n", meta_path,
-                strerror(errno));
-    free(tmp);
-    return -1;
-  }
-
-  res = write(fd, buf, sz);
-  if (res != sz) {
-    log_message(STORE_LOGLVL_WARNING, "Error writing file %s: %s\n", meta_path,
-                strerror(errno));
-    close(fd);
-    free(tmp);
-    return -1;
-  }
-
-  close(fd);
-  rename(tmp, meta_path);
-  free(tmp);
-
-  return sz;
+    return sz;
 }
 
-static int file_metatile_delete(struct storage_backend *store,
-                                const char *xmlconfig, int x, int y, int z) {
-  char meta_path[PATH_MAX];
+static int file_metatile_delete(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
+    char meta_path[PATH_MAX];
 
-  // TODO: deal with options
-  xyz_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx),
-              xmlconfig, x, y, z);
-  log_message(STORE_LOGLVL_DEBUG, "Deleting metatile from %s\n", meta_path);
-  return unlink(meta_path);
+    //TODO: deal with options
+    xyz_to_meta(meta_path, sizeof(meta_path), (char *)(store->storage_ctx), xmlconfig, x, y, z);
+    log_message(STORE_LOGLVL_DEBUG, "Deleting metatile from %s\n", meta_path);
+    return unlink(meta_path);
 }
 
-static int file_metatile_expire(struct storage_backend *store,
-                                const char *xmlconfig, int x, int y, int z) {
+static int file_metatile_expire(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
 
-  char name[PATH_MAX];
-  struct stat s;
-  static struct tm touchCalendar;
-  struct utimbuf touchTime;
+    char name[PATH_MAX];
+    struct stat s;
+    static struct tm touchCalendar;
+    struct utimbuf touchTime;
 
-  // TODO: deal with options
-  xyz_to_meta(name, sizeof(name), store->storage_ctx, xmlconfig, x, y, z);
+    //TODO: deal with options
+    xyz_to_meta(name, sizeof(name), store->storage_ctx, xmlconfig, x, y, z);
 
-  if (stat(name, &s) == 0) { // 0 is success
-    // tile exists on disk; mark it as expired
+    if (stat(name, &s) == 0) {// 0 is success
+        // tile exists on disk; mark it as expired
 
-    if (!gmtime_r(&(s.st_mtime), &touchCalendar)) {
-      touchTime.modtime = 315558000;
-    } else {
-      if (touchCalendar.tm_year >
-          105) { // Tile hasn't already been marked as expired
-        // Set the modification time to 10k days in the past (24 * 60 * 60 is 1
-        // day in seconds).
+        if (!gmtime_r(&(s.st_mtime), &touchCalendar)) {
+            touchTime.modtime = 315558000;
+        } else {
+            if (touchCalendar.tm_year > 105) { // Tile hasn't already been marked as expired
+	      // Set the modification time to 10k days in the past (24 * 60 * 60 is 1 day in seconds).
 
-        touchTime.modtime = mktime(&touchCalendar) - (864000000);
-      } else {
-        touchTime.modtime = s.st_mtime;
-      }
+	      touchTime.modtime = mktime( &touchCalendar ) - ( 864000000 );
+            } else {
+                touchTime.modtime = s.st_mtime;
+            }
+        }
+        touchTime.actime = s.st_atime; // Don't modify atime, as that is used for tile cache purging
+
+        if (-1 == utime(name, &touchTime))
+        {
+            perror("modifying timestamp failed");
+        }
     }
-    touchTime.actime = s.st_atime; // Don't modify atime, as that is used for
-                                   // tile cache purging
+    return 0;
+}
 
-    if (-1 == utime(name, &touchTime)) {
-      perror("modifying timestamp failed");
+static int file_close_storage(struct storage_backend * store) {
+    free(store->storage_ctx);
+    store->storage_ctx = NULL;
+    return 0;
+}
+
+struct storage_backend * init_storage_file(const char * tile_dir) {
+    
+    struct storage_backend * store = malloc(sizeof(struct storage_backend));
+    if (store == NULL) {
+        log_message(STORE_LOGLVL_ERR, "init_storage_file: Failed to allocate memory for storage backend");
+        return NULL;
     }
-  }
-  return 0;
-}
+    store->storage_ctx = strdup(tile_dir);
 
-static int file_close_storage(struct storage_backend *store) {
-  free(store->storage_ctx);
-  store->storage_ctx = NULL;
-  return 0;
-}
+    store->tile_read = &file_tile_read;
+    store->tile_stat = &file_tile_stat;
+    store->metatile_write = &file_metatile_write;
+    store->metatile_delete = &file_metatile_delete;
+    store->metatile_expire = &file_metatile_expire;
+    store->tile_storage_id = &file_tile_storage_id;
+    store->close_storage = &file_close_storage;
 
-struct storage_backend *init_storage_file(const char *tile_dir) {
-
-  struct storage_backend *store = malloc(sizeof(struct storage_backend));
-  if (store == NULL) {
-    log_message(
-        STORE_LOGLVL_ERR,
-        "init_storage_file: Failed to allocate memory for storage backend");
-    return NULL;
-  }
-  store->storage_ctx = strdup(tile_dir);
-
-  store->tile_read = &file_tile_read;
-  store->tile_stat = &file_tile_stat;
-  store->metatile_write = &file_metatile_write;
-  store->metatile_delete = &file_metatile_delete;
-  store->metatile_expire = &file_metatile_expire;
-  store->tile_storage_id = &file_tile_storage_id;
-  store->close_storage = &file_close_storage;
-
-  return store;
+    return store;
 }

--- a/src/store_file_utils.c
+++ b/src/store_file_utils.c
@@ -1,11 +1,11 @@
-#include <errno.h>
-#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
 
 #include "protocol.h"
 #include "render_config.h"
@@ -16,48 +16,50 @@
 // Note: the part following the trailing / is ignored
 // e.g. mkdirp("/a/b/foo.png") == shell mkdir -p /a/b
 int mkdirp(const char *path) {
-  struct stat s;
-  char tmp[PATH_MAX];
-  char *p;
+    struct stat s;
+    char tmp[PATH_MAX];
+    char *p;
 
-  strncpy(tmp, path, sizeof(tmp) - 1);
+    strncpy(tmp, path, sizeof(tmp) - 1);
 
-  // Look for parent directory
-  p = strrchr(tmp, '/');
-  if (!p)
-    return 0;
+    // Look for parent directory
+    p = strrchr(tmp, '/');
+    if (!p)
+        return 0;
 
-  *p = '\0';
+    *p = '\0';
 
-  if (!stat(tmp, &s))
-    return !S_ISDIR(s.st_mode);
-  *p = '/';
-  // Walk up the path making sure each element is a directory
-  p = tmp;
-  if (!*p)
-    return 0;
-  p++; // Ignore leading /
-  while (*p) {
-    if (*p == '/') {
-      *p = '\0';
-      if (!stat(tmp, &s)) {
-        if (!S_ISDIR(s.st_mode)) {
-          fprintf(stderr, "Error, is not a directory: %s\n", tmp);
-          return 1;
+    if (!stat(tmp, &s))
+        return !S_ISDIR(s.st_mode);
+    *p = '/';
+    // Walk up the path making sure each element is a directory
+    p = tmp;
+    if (!*p)
+        return 0;
+    p++; // Ignore leading /
+    while (*p) {
+        if (*p == '/') {
+            *p = '\0';
+            if (!stat(tmp, &s)) {
+                if (!S_ISDIR(s.st_mode)) {
+                    fprintf(stderr, "Error, is not a directory: %s\n", tmp);
+                    return 1;
+                }
+            } else if (mkdir(tmp, 0777)) {
+                    // Ignore multiple threads attempting to create the same directory
+                    if (errno != EEXIST) { 
+                       perror(tmp);
+                       return 1;
+                    }
+                }
+            *p = '/';
         }
-      } else if (mkdir(tmp, 0777)) {
-        // Ignore multiple threads attempting to create the same directory
-        if (errno != EEXIST) {
-          perror(tmp);
-          return 1;
-        }
-      }
-      *p = '/';
+        p++;
     }
-    p++;
-  }
-  return 0;
+    return 0;
 }
+
+
 
 /* File path hashing. Used by both mod_tile and render daemon
  * The two must both agree on the file layout for meta-tiling
@@ -65,131 +67,123 @@ int mkdirp(const char *path) {
  */
 
 static int check_xyz(int x, int y, int z) {
-  int oob, limit;
+    int oob, limit;
 
-  // Validate tile co-ordinates
-  oob = (z < 0 || z > MAX_ZOOM);
-  if (!oob) {
-    // valid x/y for tiles are 0 ... 2^zoom-1
-    limit = (1 << z) - 1;
-    oob = (x < 0 || x > limit || y < 0 || y > limit);
-  }
-
-  if (oob)
-    fprintf(stderr, "got bad co-ords: x(%d) y(%d) z(%d)\n", x, y, z);
-
-  return oob;
-}
-
-void xyz_to_path(char *path, size_t len, const char *tile_dir,
-                 const char *xmlconfig, int x, int y, int z) {
-#ifdef DIRECTORY_HASH
-  // We attempt to cluster the tiles so that a 16x16 square of tiles will be in
-  // a single directory Hash stores our 40 bit result of mixing the 20 bits of
-  // the x & y co-ordinates 4 bits of x & y are used per byte of output
-  unsigned char i, hash[5];
-
-  for (i = 0; i < 5; i++) {
-    hash[i] = ((x & 0x0f) << 4) | (y & 0x0f);
-    x >>= 4;
-    y >>= 4;
-  }
-  snprintf(path, len, "%s/%s/%d/%u/%u/%u/%u/%u.png", tile_dir, xmlconfig, z,
-           hash[4], hash[3], hash[2], hash[1], hash[0]);
-#else
-  snprintf(path, len, TILE_PATH "/%s/%d/%d/%d.png", xmlconfig, z, x, y);
-#endif
-  return;
-}
-
-int path_to_xyz(const char *tilepath, const char *path, char *xmlconfig,
-                int *px, int *py, int *pz) {
-#ifdef DIRECTORY_HASH
-  int i, n, hash[5], x, y, z;
-  for (i = 0; tilepath[i] && tilepath[i] == path[i]; ++i)
-    ;
-  if (tilepath[i]) {
-    fprintf(stderr, "Tile path does not match settings (%s): %s\n", tilepath,
-            path);
-    return 1;
-  }
-
-  n = sscanf(path + i, "/%40[^/]/%d/%d/%d/%d/%d/%d", xmlconfig, pz, &hash[0],
-             &hash[1], &hash[2], &hash[3], &hash[4]);
-  if (n != 7) {
-    fprintf(stderr, "Failed to parse tile path: %s\n", path);
-    return 1;
-  } else {
-    x = y = 0;
-    for (i = 0; i < 5; i++) {
-      if (hash[i] < 0 || hash[i] > 255) {
-        fprintf(stderr, "Failed to parse tile path (invalid %d): %s\n", hash[i],
-                path);
-        return 2;
-      }
-      x <<= 4;
-      y <<= 4;
-      x |= (hash[i] & 0xf0) >> 4;
-      y |= (hash[i] & 0x0f);
+    // Validate tile co-ordinates
+    oob = (z < 0 || z > MAX_ZOOM);
+    if (!oob) {
+         // valid x/y for tiles are 0 ... 2^zoom-1
+        limit = (1 << z) - 1;
+        oob =  (x < 0 || x > limit || y < 0 || y > limit);
     }
-    z = *pz;
-    *px = x;
-    *py = y;
-    return check_xyz(x, y, z);
-  }
+
+    if (oob)
+        fprintf(stderr, "got bad co-ords: x(%d) y(%d) z(%d)\n", x, y, z);
+
+    return oob;
+}
+
+void xyz_to_path(char *path, size_t len, const char *tile_dir, const char *xmlconfig, int x, int y, int z)
+{
+#ifdef DIRECTORY_HASH
+    // We attempt to cluster the tiles so that a 16x16 square of tiles will be in a single directory
+    // Hash stores our 40 bit result of mixing the 20 bits of the x & y co-ordinates
+    // 4 bits of x & y are used per byte of output
+    unsigned char i, hash[5];
+
+    for (i=0; i<5; i++) {
+        hash[i] = ((x & 0x0f) << 4) | (y & 0x0f);
+        x >>= 4;
+        y >>= 4;
+    }
+    snprintf(path, len, "%s/%s/%d/%u/%u/%u/%u/%u.png", tile_dir, xmlconfig, z, hash[4], hash[3], hash[2], hash[1], hash[0]);
 #else
-  int n;
-  n = sscanf(path, TILE_PATH "/%40[^/]/%d/%d/%d", xmlconfig, pz, px, py);
-  if (n != 4) {
-    fprintf(stderr, "Failed to parse tile path: %s\n", path);
-    return 1;
-  } else {
-    return check_xyz(*px, *py, *pz);
-  }
+    snprintf(path, len, TILE_PATH "/%s/%d/%d/%d.png", xmlconfig, z, x, y);
+#endif
+    return;
+}
+
+int path_to_xyz(const char *tilepath, const char *path, char *xmlconfig, int *px, int *py, int *pz)
+{
+#ifdef DIRECTORY_HASH
+    int i, n, hash[5], x, y, z;
+    for(i = 0; tilepath[i] && tilepath[i] == path[i]; ++i)
+        ;
+    if(tilepath[i]) {
+        fprintf(stderr, "Tile path does not match settings (%s): %s\n", tilepath, path);
+        return 1;
+    }
+
+    n = sscanf(path+i, "/%40[^/]/%d/%d/%d/%d/%d/%d", xmlconfig, pz, &hash[0], &hash[1], &hash[2], &hash[3], &hash[4]);
+    if (n != 7) {
+        fprintf(stderr, "Failed to parse tile path: %s\n", path);
+        return 1;
+    } else {
+        x = y = 0;
+        for (i=0; i<5; i++) {
+            if (hash[i] < 0 || hash[i] > 255) {
+                fprintf(stderr, "Failed to parse tile path (invalid %d): %s\n", hash[i], path);
+                return 2;
+            }
+            x <<= 4;
+            y <<= 4;
+            x |= (hash[i] & 0xf0) >> 4;
+            y |= (hash[i] & 0x0f);
+        }
+        z = *pz;
+        *px = x;
+        *py = y;
+        return check_xyz(x, y, z);
+    }
+#else
+    int n;
+    n = sscanf(path, TILE_PATH "/%40[^/]/%d/%d/%d", xmlconfig, pz, px, py);
+    if (n != 4) {
+        fprintf(stderr, "Failed to parse tile path: %s\n", path);
+        return 1;
+    } else {
+        return check_xyz(*px, *py, *pz);
+    }
 #endif
 }
 
 #ifdef METATILE
 // Returns the path to the meta-tile and the offset within the meta-tile
-int xyz_to_meta(char *path, size_t len, const char *tile_dir,
-                const char *xmlconfig, int x, int y, int z) {
-  return xyzo_to_meta(path, len, tile_dir, xmlconfig, "", x, y, z);
+int xyz_to_meta(char *path, size_t len, const char *tile_dir, const char *xmlconfig, int x, int y, int z)
+{
+    return xyzo_to_meta(path, len, tile_dir, xmlconfig, "", x, y, z);
 }
 
 // Returns the path to the meta-tile and the offset within the meta-tile
-int xyzo_to_meta(char *path, size_t len, const char *tile_dir,
-                 const char *xmlconfig, const char *options, int x, int y,
-                 int z) {
-  unsigned char i, hash[5], offset, mask;
+int xyzo_to_meta(char *path, size_t len, const char *tile_dir, const char *xmlconfig, const char *options, int x, int y, int z)
+{
+    unsigned char i, hash[5], offset, mask;
 
-  // Each meta tile winds up in its own file, with several in each leaf
-  // directory the .meta tile name is beasd on the sub-tile at (0,0)
-  mask = METATILE - 1;
-  offset = (x & mask) * METATILE + (y & mask);
-  x &= ~mask;
-  y &= ~mask;
+    // Each meta tile winds up in its own file, with several in each leaf directory
+    // the .meta tile name is beasd on the sub-tile at (0,0)
+    mask = METATILE - 1;
+    offset = (x & mask) * METATILE + (y & mask);
+    x &= ~mask;
+    y &= ~mask;
 
-  for (i = 0; i < 5; i++) {
-    hash[i] = ((x & 0x0f) << 4) | (y & 0x0f);
-    x >>= 4;
-    y >>= 4;
-  }
+    for (i=0; i<5; i++) {
+        hash[i] = ((x & 0x0f) << 4) | (y & 0x0f);
+        x >>= 4;
+        y >>= 4;
+    }
 #ifdef DIRECTORY_HASH
-  if (strlen(options)) {
-    snprintf(path, len, "%s/%s/%d/%u/%u/%u/%u/%u.%s.meta", tile_dir, xmlconfig,
-             z, hash[4], hash[3], hash[2], hash[1], hash[0], options);
-  } else {
-    snprintf(path, len, "%s/%s/%d/%u/%u/%u/%u/%u.meta", tile_dir, xmlconfig, z,
-             hash[4], hash[3], hash[2], hash[1], hash[0]);
-  }
+    if (strlen(options)) {
+        snprintf(path, len, "%s/%s/%d/%u/%u/%u/%u/%u.%s.meta", tile_dir, xmlconfig, z, hash[4], hash[3], hash[2], hash[1], hash[0], options);
+    } else {
+        snprintf(path, len, "%s/%s/%d/%u/%u/%u/%u/%u.meta", tile_dir, xmlconfig, z, hash[4], hash[3], hash[2], hash[1], hash[0]);
+    }
 #else
-  if (strlen(options)) {
-    snprintf(path, len, "%s/%s/%d/%u/%u.%s.meta", tile_dir, xmlconfig, z, x, y,
-             options);
-  } else {
-    snprintf(path, len, "%s/%s/%d/%u/%u.meta", tile_dir, xmlconfig, z, x, y);
-  }
+    if (strlen(options)) {
+        snprintf(path, len, "%s/%s/%d/%u/%u.%s.meta", tile_dir, xmlconfig, z, x, y, options);
+    } else {
+        snprintf(path, len, "%s/%s/%d/%u/%u.meta", tile_dir, xmlconfig, z, x, y);
+    }
 #endif
-  return offset;
+    return offset;
 }
 #endif

--- a/src/store_memcached.c
+++ b/src/store_memcached.c
@@ -7,301 +7,266 @@
  */
 
 #include "config.h"
-#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
 #include <string.h>
 #include <sys/types.h>
 #include <time.h>
-#include <unistd.h>
 
 #ifdef HAVE_LIBMEMCACHED
 #include <libmemcached/memcached.h>
 #endif
 
-#include "metatile.h"
-#include "protocol.h"
-#include "render_config.h"
 #include "store.h"
+#include "metatile.h"
+#include "render_config.h"
+#include "protocol.h"
+
 
 #ifdef HAVE_LIBMEMCACHED
-static char *memcached_xyzo_to_storagekey(const char *xmlconfig,
-                                          const char *options, int x, int y,
-                                          int z, char *key) {
-  int mask;
+static char * memcached_xyzo_to_storagekey(const char *xmlconfig, const char *options, int x, int y, int z, char * key) {
+    int mask;
 
-  mask = METATILE - 1;
-  x &= ~mask;
-  y &= ~mask;
+    mask = METATILE - 1;
+    x &= ~mask;
+    y &= ~mask;
 
-  if (strlen(options)) {
-    snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.%s.meta", xmlconfig, x, y, z,
-             options);
-  } else {
-    snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.meta", xmlconfig, x, y, z);
-  }
-
-  return key;
-}
-
-static char *memcached_xyz_to_storagekey(const char *xmlconfig, int x, int y,
-                                         int z, char *key) {
-  return memcached_xyzo_to_storagekey(xmlconfig, "", x, y, z, key);
-}
-
-static int memcached_tile_read(struct storage_backend *store,
-                               const char *xmlconfig, const char *options,
-                               int x, int y, int z, char *buf, size_t sz,
-                               int *compressed, char *log_msg) {
-
-  char meta_path[PATH_MAX];
-  int meta_offset;
-  unsigned int header_len =
-      sizeof(struct meta_layout) + METATILE * METATILE * sizeof(struct entry);
-  struct meta_layout *m = (struct meta_layout *)malloc(header_len);
-  size_t file_offset, tile_size;
-  int mask;
-  uint32_t flags;
-  size_t len;
-  memcached_return_t rc;
-  char *buf_raw;
-
-  mask = METATILE - 1;
-  meta_offset = (x & mask) * METATILE + (y & mask);
-
-  memcached_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-  buf_raw = memcached_get(store->storage_ctx, meta_path, strlen(meta_path),
-                          &len, &flags, &rc);
-
-  if (rc != MEMCACHED_SUCCESS) {
-    free(m);
-    return -1;
-  }
-
-  memcpy(m, buf_raw + sizeof(struct stat_info), header_len);
-
-  if (memcmp(m->magic, META_MAGIC, strlen(META_MAGIC))) {
-    if (memcmp(m->magic, META_MAGIC_COMPRESSED,
-               strlen(META_MAGIC_COMPRESSED))) {
-      snprintf(log_msg, 1024, "Meta file header magic mismatch\n");
-      free(m);
-      return -4;
+    if (strlen(options)) {
+        snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.%s.meta", xmlconfig, x, y, z, options);
     } else {
-      *compressed = 1;
+        snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.meta", xmlconfig, x, y, z);
     }
-  } else
-    *compressed = 0;
 
-  // Currently this code only works with fixed metatile sizes (due to
-  // xyz_to_meta above)
-  if (m->count != (METATILE * METATILE)) {
-    snprintf(log_msg, 1024, "Meta file header bad count %d != %d\n", m->count,
-             METATILE * METATILE);
+    return key;
+}
+
+static char * memcached_xyz_to_storagekey(const char *xmlconfig, int x, int y, int z, char * key) {
+    return memcached_xyzo_to_storagekey(xmlconfig, "", x, y, z, key);
+}
+
+static int memcached_tile_read(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg) {
+
+    char meta_path[PATH_MAX];
+    int meta_offset;
+    unsigned int header_len = sizeof(struct meta_layout) + METATILE*METATILE*sizeof(struct entry);
+    struct meta_layout *m = (struct meta_layout *)malloc(header_len);
+    size_t file_offset, tile_size;
+    int mask;
+    uint32_t flags;
+    size_t len;
+    memcached_return_t rc;
+    char * buf_raw;
+
+    mask = METATILE - 1;
+    meta_offset = (x & mask) * METATILE + (y & mask);
+
+    memcached_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
+    buf_raw = memcached_get(store->storage_ctx, meta_path, strlen(meta_path), &len, &flags, &rc);
+
+    if (rc != MEMCACHED_SUCCESS) {
+        free(m);
+        return -1;
+    }
+
+    memcpy(m, buf_raw + sizeof(struct stat_info), header_len);
+
+    if (memcmp(m->magic, META_MAGIC, strlen(META_MAGIC))) {
+        if (memcmp(m->magic, META_MAGIC_COMPRESSED, strlen(META_MAGIC_COMPRESSED))) {
+            snprintf(log_msg,1024, "Meta file header magic mismatch\n");
+            free(m);
+            return -4;
+        } else {
+            *compressed = 1;
+        }
+    } else *compressed = 0;
+
+    // Currently this code only works with fixed metatile sizes (due to xyz_to_meta above)
+    if (m->count != (METATILE * METATILE)) {
+        snprintf(log_msg, 1024, "Meta file header bad count %d != %d\n", m->count, METATILE * METATILE);
+        free(m);
+        return -5;
+    }
+
+    file_offset = m->index[meta_offset].offset + sizeof(struct stat_info);
+    tile_size   = m->index[meta_offset].size;
+
     free(m);
-    return -5;
-  }
 
-  file_offset = m->index[meta_offset].offset + sizeof(struct stat_info);
-  tile_size = m->index[meta_offset].size;
+    if (tile_size > sz) {
+        snprintf(log_msg, 1024, "Truncating tile %zd to fit buffer of %zd\n", tile_size, sz);
+        tile_size = sz;
+        return -6;
+    }
 
-  free(m);
-
-  if (tile_size > sz) {
-    snprintf(log_msg, 1024, "Truncating tile %zd to fit buffer of %zd\n",
-             tile_size, sz);
-    tile_size = sz;
-    return -6;
-  }
-
-  memcpy(buf, buf_raw + file_offset, tile_size);
-  free(buf_raw);
-  return tile_size;
+    memcpy(buf, buf_raw + file_offset, tile_size);
+    free(buf_raw);
+    return tile_size;
 }
 
-static struct stat_info memcached_tile_stat(struct storage_backend *store,
-                                            const char *xmlconfig,
-                                            const char *options, int x, int y,
-                                            int z) {
-  struct stat_info tile_stat;
-  char meta_path[PATH_MAX];
-  unsigned int header_len =
-      sizeof(struct meta_layout) + METATILE * METATILE * sizeof(struct entry);
-  struct meta_layout *m = (struct meta_layout *)malloc(header_len);
-  char *buf;
-  size_t len;
-  uint32_t flags;
-  memcached_return_t rc;
-  int offset, mask;
+static struct stat_info memcached_tile_stat(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z) {
+    struct stat_info tile_stat;
+    char meta_path[PATH_MAX];
+    unsigned int header_len = sizeof(struct meta_layout) + METATILE*METATILE*sizeof(struct entry);
+    struct meta_layout *m = (struct meta_layout *)malloc(header_len);
+    char * buf;
+    size_t len;
+    uint32_t flags;
+    memcached_return_t rc;
+    int offset, mask;
 
-  mask = METATILE - 1;
-  offset = (x & mask) * METATILE + (y & mask);
+    mask = METATILE - 1;
+    offset = (x & mask) * METATILE + (y & mask);
 
-  memcached_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-  buf = memcached_get(store->storage_ctx, meta_path, strlen(meta_path), &len,
-                      &flags, &rc);
+    memcached_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
+    buf = memcached_get(store->storage_ctx, meta_path, strlen(meta_path), &len, &flags, &rc);
 
-  if (rc != MEMCACHED_SUCCESS) {
-    tile_stat.size = -1;
-    tile_stat.expired = 0;
-    tile_stat.mtime = 0;
-    tile_stat.atime = 0;
-    tile_stat.ctime = 0;
+    if (rc != MEMCACHED_SUCCESS) {
+        tile_stat.size = -1;
+        tile_stat.expired = 0;
+        tile_stat.mtime = 0;
+        tile_stat.atime = 0;
+        tile_stat.ctime = 0;
+        free(m);
+        return tile_stat;
+    }
+
+    memcpy(&tile_stat,buf, sizeof(struct stat_info));
+    memcpy(m, buf + sizeof(struct stat_info), header_len);
+    tile_stat.size = m->index[offset].size;
+
     free(m);
-    return tile_stat;
-  }
-
-  memcpy(&tile_stat, buf, sizeof(struct stat_info));
-  memcpy(m, buf + sizeof(struct stat_info), header_len);
-  tile_stat.size = m->index[offset].size;
-
-  free(m);
-  free(buf);
-  return tile_stat;
-}
-
-static char *memcached_tile_storage_id(struct storage_backend *store,
-                                       const char *xmlconfig,
-                                       const char *options, int x, int y, int z,
-                                       char *string) {
-
-  snprintf(string, PATH_MAX - 1, "memcached:///%s/%d/%d/%d.meta", xmlconfig, x,
-           y, z);
-  return string;
-}
-
-static int memcached_metatile_write(struct storage_backend *store,
-                                    const char *xmlconfig, const char *options,
-                                    int x, int y, int z, const char *buf,
-                                    int sz) {
-  char meta_path[PATH_MAX];
-  char tmp[PATH_MAX];
-  struct stat_info tile_stat;
-  int sz2 = sz + sizeof(struct stat_info);
-  char *buf2 = malloc(sz2);
-  memcached_return_t rc;
-
-  if (buf2 == NULL) {
-    return -2;
-  }
-
-  tile_stat.expired = 0;
-  tile_stat.size = sz;
-  tile_stat.mtime = time(NULL);
-  tile_stat.atime = tile_stat.mtime;
-  tile_stat.ctime = tile_stat.mtime;
-
-  memcpy(buf2, &tile_stat, sizeof(tile_stat));
-  memcpy(buf2 + sizeof(tile_stat), buf, sz);
-
-  log_message(
-      STORE_LOGLVL_DEBUG, "Trying to create and write a metatile to %s\n",
-      memcached_tile_storage_id(store, xmlconfig, options, x, y, z, tmp));
-
-  snprintf(meta_path, PATH_MAX - 1, "%s/%d/%d/%d.meta", xmlconfig, x, y, z);
-
-  rc = memcached_set(store->storage_ctx, meta_path, strlen(meta_path), buf2,
-                     sz2, (time_t)0, (uint32_t)0);
-  free(buf2);
-
-  if (rc != MEMCACHED_SUCCESS) {
-    return -1;
-  }
-  memcached_flush_buffers(store->storage_ctx);
-  return sz;
-}
-
-static int memcached_metatile_delete(struct storage_backend *store,
-                                     const char *xmlconfig, int x, int y,
-                                     int z) {
-  char meta_path[PATH_MAX];
-  memcached_return_t rc;
-
-  // TODO: deal with options
-  memcached_xyz_to_storagekey(xmlconfig, x, y, z, meta_path);
-
-  rc = memcached_delete(store->storage_ctx, meta_path, strlen(meta_path), 0);
-
-  if (rc != MEMCACHED_SUCCESS) {
-    return -1;
-  }
-
-  return 0;
-}
-
-static int memcached_metatile_expire(struct storage_backend *store,
-                                     const char *xmlconfig, int x, int y,
-                                     int z) {
-
-  char meta_path[PATH_MAX];
-  char *buf;
-  size_t len;
-  uint32_t flags;
-  uint64_t cas;
-  memcached_return_t rc;
-
-  // TODO: deal with options
-  memcached_xyz_to_storagekey(xmlconfig, x, y, z, meta_path);
-  buf = memcached_get(store->storage_ctx, meta_path, strlen(meta_path), &len,
-                      &flags, &rc);
-
-  if (rc != MEMCACHED_SUCCESS) {
-    return -1;
-  }
-  // cas = memcached_result_cas(&rc);
-
-  ((struct stat_info *)buf)->expired = 1;
-
-  rc = memcached_cas(store->storage_ctx, meta_path, strlen(meta_path), buf, len,
-                     0, flags, cas);
-
-  if (rc != MEMCACHED_SUCCESS) {
     free(buf);
-    return -1;
-  }
-
-  free(buf);
-  return 0;
+    return tile_stat;
 }
 
-static int memcached_close_storage(struct storage_backend *store) {
-  memcached_free(store->storage_ctx);
-  return 0;
+
+static char * memcached_tile_storage_id(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string) {
+
+    snprintf(string,PATH_MAX - 1, "memcached:///%s/%d/%d/%d.meta", xmlconfig, x, y, z);
+    return string;
 }
-#endif // Have memcached
 
-struct storage_backend *init_storage_memcached(const char *connection_string) {
+static int memcached_metatile_write(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz) {
+    char meta_path[PATH_MAX];
+    char tmp[PATH_MAX];
+    struct stat_info tile_stat;
+    int sz2 = sz + sizeof(struct stat_info);
+    char * buf2 = malloc(sz2);
+    memcached_return_t rc;
 
+    if (buf2 == NULL) {
+        return -2;
+    }
+
+    tile_stat.expired = 0;
+    tile_stat.size = sz;
+    tile_stat.mtime = time(NULL);
+    tile_stat.atime = tile_stat.mtime;
+    tile_stat.ctime = tile_stat.mtime;
+
+    memcpy(buf2, &tile_stat, sizeof(tile_stat));
+    memcpy(buf2 + sizeof(tile_stat), buf, sz);
+
+    log_message(STORE_LOGLVL_DEBUG, "Trying to create and write a metatile to %s\n", memcached_tile_storage_id(store, xmlconfig, options, x, y, z, tmp));
+ 
+    snprintf(meta_path,PATH_MAX - 1, "%s/%d/%d/%d.meta", xmlconfig, x, y, z);
+
+    rc = memcached_set(store->storage_ctx, meta_path, strlen(meta_path), buf2, sz2, (time_t)0, (uint32_t)0);
+    free(buf2);
+
+    if (rc != MEMCACHED_SUCCESS) {
+        return -1;
+    }
+    memcached_flush_buffers(store->storage_ctx);
+    return sz;
+}
+
+
+static int memcached_metatile_delete(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
+    char meta_path[PATH_MAX];
+    memcached_return_t rc;
+
+    //TODO: deal with options
+    memcached_xyz_to_storagekey(xmlconfig, x, y, z, meta_path);
+
+    rc = memcached_delete(store->storage_ctx, meta_path, strlen(meta_path), 0);
+
+    if (rc != MEMCACHED_SUCCESS) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int memcached_metatile_expire(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
+
+    char meta_path[PATH_MAX];
+    char * buf;
+    size_t len;
+    uint32_t flags;
+    uint64_t cas;
+    memcached_return_t rc;
+
+    //TODO: deal with options
+    memcached_xyz_to_storagekey(xmlconfig, x, y, z, meta_path);
+    buf = memcached_get(store->storage_ctx, meta_path, strlen(meta_path), &len, &flags, &rc);
+
+    if (rc != MEMCACHED_SUCCESS) {
+        return -1;
+    }
+    //cas = memcached_result_cas(&rc);
+
+    ((struct stat_info *)buf)->expired = 1;
+
+    rc = memcached_cas(store->storage_ctx, meta_path, strlen(meta_path), buf, len, 0, flags, cas);
+
+    if (rc != MEMCACHED_SUCCESS) {
+        free(buf);
+        return -1;
+    }
+
+    free(buf);
+    return 0;
+}
+
+static int memcached_close_storage(struct storage_backend * store) {
+    memcached_free(store->storage_ctx);
+    return 0;
+}
+#endif //Have memcached
+
+struct storage_backend * init_storage_memcached(const char * connection_string) {
+    
 #ifndef HAVE_LIBMEMCACHED
-  log_message(STORE_LOGLVL_ERR, "init_storage_memcached: Support for memcached "
-                                "has not been compiled into this program");
-  return NULL;
+    log_message(STORE_LOGLVL_ERR,"init_storage_memcached: Support for memcached has not been compiled into this program");
+    return NULL;
 #else
-  struct storage_backend *store = malloc(sizeof(struct storage_backend));
-  memcached_st *ctx;
-  char *connection_str = "--server=localhost";
+    struct storage_backend * store = malloc(sizeof(struct storage_backend));
+    memcached_st * ctx;
+    char * connection_str = "--server=localhost";
 
-  if (store == NULL) {
-    log_message(STORE_LOGLVL_ERR, "init_storage_memcached: Failed to allocate "
-                                  "memory for storage backend");
-    return NULL;
-  }
-  ctx = memcached(connection_str, strlen(connection_str));
-  if (ctx == NULL) {
-    log_message(STORE_LOGLVL_ERR,
-                "init_storage_memcached: Failed to create memcached ctx");
-    free(store);
-    return NULL;
-  }
-  store->storage_ctx = ctx;
+    if (store == NULL) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_memcached: Failed to allocate memory for storage backend");
+        return NULL;
+    }
+    ctx = memcached(connection_str, strlen(connection_str));
+    if (ctx == NULL) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_memcached: Failed to create memcached ctx");
+        free(store);
+        return NULL;
+    }
+    store->storage_ctx = ctx;
 
-  store->tile_read = &memcached_tile_read;
-  store->tile_stat = &memcached_tile_stat;
-  store->metatile_write = &memcached_metatile_write;
-  store->metatile_delete = &memcached_metatile_delete;
-  store->metatile_expire = &memcached_metatile_expire;
-  store->tile_storage_id = &memcached_tile_storage_id;
-  store->close_storage = &memcached_close_storage;
+    store->tile_read = &memcached_tile_read;
+    store->tile_stat = &memcached_tile_stat;
+    store->metatile_write = &memcached_metatile_write;
+    store->metatile_delete = &memcached_metatile_delete;
+    store->metatile_expire = &memcached_metatile_expire;
+    store->tile_storage_id = &memcached_tile_storage_id;
+    store->close_storage = &memcached_close_storage;
 
-  return store;
+    return store;
 #endif
 }

--- a/src/store_null.c
+++ b/src/store_null.c
@@ -1,71 +1,81 @@
 #include "store_null.h"
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
 
-static int tile_read(struct storage_backend *store, const char *xmlconfig,
-                     const char *options, int x, int y, int z, char *buf,
-                     size_t sz, int *compressed, char *err_msg) {
-  snprintf(err_msg, PATH_MAX - 1, "Cannot read from NULL storage.");
-  return -1;
+static int tile_read(struct storage_backend * store, 
+		     const char *xmlconfig, 
+             const char *options,
+		     int x, int y, int z, 
+		     char *buf, size_t sz, 
+		     int * compressed, char * err_msg) {
+   snprintf(err_msg, PATH_MAX - 1, "Cannot read from NULL storage.");
+   return -1;
 }
 
-static struct stat_info tile_stat(struct storage_backend *store,
-                                  const char *xmlconfig, const char *options,
-                                  int x, int y, int z) {
-  struct stat_info tile_stat;
-  tile_stat.size = -1;
-  tile_stat.atime = 0;
-  tile_stat.mtime = 0;
-  tile_stat.ctime = 0;
-  tile_stat.expired = 1;
-  return tile_stat;
+static struct stat_info tile_stat(struct storage_backend * store, 
+				  const char *xmlconfig, 
+                  const char *options,
+				  int x, int y, int z) {
+   struct stat_info tile_stat;
+   tile_stat.size = -1;
+   tile_stat.atime = 0;
+   tile_stat.mtime = 0;
+   tile_stat.ctime = 0;
+   tile_stat.expired = 1;
+   return tile_stat;
 }
 
-static int metatile_write(struct storage_backend *store, const char *xmlconfig,
-                          const char *options, int x, int y, int z,
-                          const char *buf, int sz) {
-  // fake like we actually wrote the tile, but we didn't...
-  return sz;
+static int metatile_write(struct storage_backend * store, 
+			  const char *xmlconfig,
+              const char *options,
+			  int x, int y, int z, 
+			  const char *buf, int sz) {
+   // fake like we actually wrote the tile, but we didn't...
+   return sz;
 }
 
-static int metatile_delete(struct storage_backend *store, const char *xmlconfig,
-                           int x, int y, int z) {
-  return 0;
+static int metatile_delete(struct storage_backend * store, 
+			   const char *xmlconfig, 
+			   int x, int y, int z) {
+   return 0;
 }
 
-static int metatile_expire(struct storage_backend *store, const char *xmlconfig,
-                           int x, int y, int z) {
-  return 0;
+static int metatile_expire(struct storage_backend * store, 
+			   const char *xmlconfig, 
+			   int x, int y, int z) {
+   return 0;
 }
 
-static char *tile_storage_id(struct storage_backend *store,
-                             const char *xmlconfig, const char *options, int x,
-                             int y, int z, char *string) {
-  snprintf(string, PATH_MAX - 1, "null://");
-  return string;
+static char * tile_storage_id(struct storage_backend * store, 
+			      const char *xmlconfig, 
+                  const char *options,
+			      int x, int y, int z, 
+			      char * string) {
+   snprintf(string, PATH_MAX - 1, "null://");
+   return string;
 }
 
-static int close_storage(struct storage_backend *store) { return 0; }
+static int close_storage(struct storage_backend * store) {
+   return 0;
+}
 
 struct storage_backend *init_storage_null() {
-  struct storage_backend *store = malloc(sizeof *store);
-  if (store == NULL) {
-    log_message(
-        STORE_LOGLVL_ERR,
-        "init_storage_null: Failed to allocate memory for storage backend");
-    return NULL;
-  }
+   struct storage_backend *store = malloc(sizeof *store);
+   if (store == NULL) {
+      log_message(STORE_LOGLVL_ERR, "init_storage_null: Failed to allocate memory for storage backend");
+      return NULL;
+   }
 
-  store->storage_ctx = NULL;
-  store->tile_read = &tile_read;
-  store->tile_stat = &tile_stat;
-  store->metatile_write = &metatile_write;
-  store->metatile_delete = &metatile_delete;
-  store->metatile_expire = &metatile_expire;
-  store->tile_storage_id = &tile_storage_id;
-  store->close_storage = &close_storage;
+   store->storage_ctx = NULL;
+   store->tile_read = &tile_read;
+   store->tile_stat = &tile_stat;
+   store->metatile_write = &metatile_write;
+   store->metatile_delete = &metatile_delete;
+   store->metatile_expire = &metatile_expire;
+   store->tile_storage_id = &tile_storage_id;
+   store->close_storage = &close_storage;
 
-  return store;
+   return store;
 }

--- a/src/store_rados.c
+++ b/src/store_rados.c
@@ -7,449 +7,387 @@
  */
 
 #include "config.h"
-#include <errno.h>
-#include <limits.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
 #include <string.h>
 #include <sys/types.h>
 #include <time.h>
-#include <unistd.h>
+#include <errno.h>
+#include <pthread.h>
 
 #ifdef HAVE_LIBRADOS
 #include <rados/librados.h>
 #endif
 
-#include "metatile.h"
-#include "protocol.h"
-#include "render_config.h"
 #include "store.h"
 #include "store_rados.h"
+#include "metatile.h"
+#include "render_config.h"
+#include "protocol.h"
+
 
 #ifdef HAVE_LIBRADOS
 
 static pthread_mutex_t qLock;
 
 struct metadata_cache {
-  char *data;
-  int x, y, z;
-  char xmlname[XMLCONFIG_MAX];
+    char * data;
+    int x,y,z;
+    char xmlname[XMLCONFIG_MAX];
 };
 
 struct rados_ctx {
-  char *pool;
-  rados_t cluster;
-  rados_ioctx_t io;
-  struct metadata_cache metadata_cache;
+    char * pool;
+    rados_t cluster;
+    rados_ioctx_t io;
+    struct metadata_cache metadata_cache;
 };
 
-static char *rados_xyzo_to_storagekey(const char *xmlconfig,
-                                      const char *options, int x, int y, int z,
-                                      char *key) {
-  int mask;
+static char * rados_xyzo_to_storagekey(const char *xmlconfig, const char *options, int x, int y, int z, char * key) {
+    int mask;
 
-  mask = METATILE - 1;
-  x &= ~mask;
-  y &= ~mask;
+    mask = METATILE - 1;
+    x &= ~mask;
+    y &= ~mask;
 
-  if (strlen(options)) {
-    snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.%s.meta", xmlconfig, z, x, y,
-             options);
-  } else {
-    snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.meta", xmlconfig, z, x, y);
-  }
+    if (strlen(options)) {
+        snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.%s.meta", xmlconfig, z, x, y, options);
+    } else {
+        snprintf(key, PATH_MAX - 1, "%s/%d/%d/%d.meta", xmlconfig, z, x, y);
+    }
 
-  return key;
+    return key;
 }
 
-static char *read_meta_data(struct storage_backend *store,
-                            const char *xmlconfig, const char *options, int x,
-                            int y, int z) {
-  int mask;
-  int err;
-  char meta_path[PATH_MAX];
-  struct rados_ctx *ctx = (struct rados_ctx *)store->storage_ctx;
-  unsigned int header_len = sizeof(struct stat_info) +
-                            sizeof(struct meta_layout) +
-                            METATILE * METATILE * sizeof(struct entry);
+static char * read_meta_data(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z) {
+    int mask;
+    int err;
+    char meta_path[PATH_MAX];
+    struct rados_ctx * ctx = (struct rados_ctx *)store->storage_ctx;
+    unsigned int header_len = sizeof(struct stat_info) + sizeof(struct meta_layout) + METATILE*METATILE*sizeof(struct entry);
 
-  mask = METATILE - 1;
-  x &= ~mask;
-  y &= ~mask;
+    mask = METATILE - 1;
+    x &= ~mask;
+    y &= ~mask;
 
-  if ((ctx->metadata_cache.x == x) && (ctx->metadata_cache.y == y) &&
-      (ctx->metadata_cache.z == z) &&
-      (strcmp(ctx->metadata_cache.xmlname, xmlconfig) == 0)) {
-    // log_message(STORE_LOGLVL_DEBUG, "Returning cached data for %s %i %i %i",
-    // ctx->metadata_cache.xmlname, ctx->metadata_cache.x, ctx->metadata_cache.y,
-    // ctx->metadata_cache.z);
-    return ctx->metadata_cache.data;
-  } else {
-    // log_message(STORE_LOGLVL_DEBUG, "Retrieving fresh metadata");
+    if ((ctx->metadata_cache.x == x) && (ctx->metadata_cache.y == y) && (ctx->metadata_cache.z == z) && (strcmp(ctx->metadata_cache.xmlname, xmlconfig) == 0)) {
+        //log_message(STORE_LOGLVL_DEBUG, "Returning cached data for %s %i %i %i", ctx->metadata_cache.xmlname, ctx->metadata_cache.x, ctx->metadata_cache.y, ctx->metadata_cache.z);
+        return ctx->metadata_cache.data;
+    } else {
+        //log_message(STORE_LOGLVL_DEBUG, "Retrieving fresh metadata");
+        rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
+        err = rados_read(ctx->io, meta_path, ctx->metadata_cache.data, header_len, 0);
+
+        if (err < 0) {
+            if (-err == ENOENT) {
+                log_message(STORE_LOGLVL_DEBUG, "cannot read data from rados pool %s: %s\n", ctx->pool, strerror(-err));
+            } else {
+                log_message(STORE_LOGLVL_ERR, "cannot read data from rados pool %s: %s\n", ctx->pool, strerror(-err));
+            }
+            ctx->metadata_cache.x = -1;
+            ctx->metadata_cache.y = -1;
+            ctx->metadata_cache.z = -1;
+            return NULL;
+        }
+        ctx->metadata_cache.x = x;
+        ctx->metadata_cache.y = y;
+        ctx->metadata_cache.z = z;
+        strncpy(ctx->metadata_cache.xmlname, xmlconfig, XMLCONFIG_MAX - 1);
+        return ctx->metadata_cache.data;
+    }
+}
+
+
+static int rados_tile_read(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg) {
+
+    char meta_path[PATH_MAX];
+    int meta_offset;
+    unsigned int header_len = sizeof(struct meta_layout) + METATILE*METATILE*sizeof(struct entry);
+    struct meta_layout *m = (struct meta_layout *)malloc(header_len);
+    size_t file_offset, tile_size;
+    int mask;
+    int err;
+    char * buf_raw;
+
+    mask = METATILE - 1;
+    meta_offset = (x & mask) * METATILE + (y & mask);
+
     rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-    err =
-        rados_read(ctx->io, meta_path, ctx->metadata_cache.data, header_len, 0);
+
+    buf_raw = read_meta_data(store, xmlconfig, options, x, y, z);
+    if (buf_raw == NULL) {
+        snprintf(log_msg,1024, "Failed to read metadata of tile\n");
+        free(m);
+        return -3;
+    }
+
+    memcpy(m, buf_raw + sizeof(struct stat_info), header_len);
+
+    if (memcmp(m->magic, META_MAGIC, strlen(META_MAGIC))) {
+        if (memcmp(m->magic, META_MAGIC_COMPRESSED, strlen(META_MAGIC_COMPRESSED))) {
+            snprintf(log_msg,1024, "Meta file header magic mismatch\n");
+            free(m);
+            return -4;
+        } else {
+            *compressed = 1;
+        }
+    } else *compressed = 0;
+
+    // Currently this code only works with fixed metatile sizes (due to xyz_to_meta above)
+    if (m->count != (METATILE * METATILE)) {
+        snprintf(log_msg, 1024, "Meta file header bad count %d != %d\n", m->count, METATILE * METATILE);
+        free(m);
+        return -5;
+    }
+
+    file_offset = m->index[meta_offset].offset + sizeof(struct stat_info);
+    tile_size   = m->index[meta_offset].size;
+
+    free(m);
+
+    if (tile_size > sz) {
+        snprintf(log_msg, 1024, "Truncating tile %zd to fit buffer of %zd\n", tile_size, sz);
+        tile_size = sz;
+        return -6;
+    }
+
+    err = rados_read(((struct rados_ctx *)store->storage_ctx)->io, meta_path, buf, tile_size, file_offset);
 
     if (err < 0) {
-      if (-err == ENOENT) {
-        log_message(STORE_LOGLVL_DEBUG,
-                    "cannot read data from rados pool %s: %s\n", ctx->pool,
-                    strerror(-err));
-      } else {
-        log_message(STORE_LOGLVL_ERR,
-                    "cannot read data from rados pool %s: %s\n", ctx->pool,
-                    strerror(-err));
-      }
-      ctx->metadata_cache.x = -1;
-      ctx->metadata_cache.y = -1;
-      ctx->metadata_cache.z = -1;
-      return NULL;
+        snprintf(log_msg, 1024, "Failed to read tile data from rados %s offset: %li length: %li: %s\n", meta_path, file_offset, tile_size, strerror(-err));
+        return -1;
     }
-    ctx->metadata_cache.x = x;
-    ctx->metadata_cache.y = y;
-    ctx->metadata_cache.z = z;
-    strncpy(ctx->metadata_cache.xmlname, xmlconfig, XMLCONFIG_MAX - 1);
-    return ctx->metadata_cache.data;
-  }
+
+    return tile_size;
 }
 
-static int rados_tile_read(struct storage_backend *store, const char *xmlconfig,
-                           const char *options, int x, int y, int z, char *buf,
-                           size_t sz, int *compressed, char *log_msg) {
+static struct stat_info rados_tile_stat(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z) {
+    struct stat_info tile_stat;
+    char * buf;
+    int offset, mask;
 
-  char meta_path[PATH_MAX];
-  int meta_offset;
-  unsigned int header_len =
-      sizeof(struct meta_layout) + METATILE * METATILE * sizeof(struct entry);
-  struct meta_layout *m = (struct meta_layout *)malloc(header_len);
-  size_t file_offset, tile_size;
-  int mask;
-  int err;
-  char *buf_raw;
+    mask = METATILE - 1;
+    offset = (x & mask) * METATILE + (y & mask);
 
-  mask = METATILE - 1;
-  meta_offset = (x & mask) * METATILE + (y & mask);
-
-  rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-
-  buf_raw = read_meta_data(store, xmlconfig, options, x, y, z);
-  if (buf_raw == NULL) {
-    snprintf(log_msg, 1024, "Failed to read metadata of tile\n");
-    free(m);
-    return -3;
-  }
-
-  memcpy(m, buf_raw + sizeof(struct stat_info), header_len);
-
-  if (memcmp(m->magic, META_MAGIC, strlen(META_MAGIC))) {
-    if (memcmp(m->magic, META_MAGIC_COMPRESSED,
-               strlen(META_MAGIC_COMPRESSED))) {
-      snprintf(log_msg, 1024, "Meta file header magic mismatch\n");
-      free(m);
-      return -4;
-    } else {
-      *compressed = 1;
+    buf = read_meta_data(store, xmlconfig, options, x, y, z);
+    if (buf == NULL) {
+        tile_stat.size = -1;
+        tile_stat.expired = 0;
+        tile_stat.mtime = 0;
+        tile_stat.atime = 0;
+        tile_stat.ctime = 0;
+        return tile_stat;
     }
-  } else
-    *compressed = 0;
 
-  // Currently this code only works with fixed metatile sizes (due to
-  // xyz_to_meta above)
-  if (m->count != (METATILE * METATILE)) {
-    snprintf(log_msg, 1024, "Meta file header bad count %d != %d\n", m->count,
-             METATILE * METATILE);
-    free(m);
-    return -5;
-  }
+    memcpy(&tile_stat,buf, sizeof(struct stat_info));
+    tile_stat.size = ((struct meta_layout *) (buf + sizeof(struct stat_info)))->index[offset].size;
 
-  file_offset = m->index[meta_offset].offset + sizeof(struct stat_info);
-  tile_size = m->index[meta_offset].size;
-
-  free(m);
-
-  if (tile_size > sz) {
-    snprintf(log_msg, 1024, "Truncating tile %zd to fit buffer of %zd\n",
-             tile_size, sz);
-    tile_size = sz;
-    return -6;
-  }
-
-  err = rados_read(((struct rados_ctx *)store->storage_ctx)->io, meta_path, buf,
-                   tile_size, file_offset);
-
-  if (err < 0) {
-    snprintf(
-        log_msg, 1024,
-        "Failed to read tile data from rados %s offset: %li length: %li: %s\n",
-        meta_path, file_offset, tile_size, strerror(-err));
-    return -1;
-  }
-
-  return tile_size;
-}
-
-static struct stat_info rados_tile_stat(struct storage_backend *store,
-                                        const char *xmlconfig,
-                                        const char *options, int x, int y,
-                                        int z) {
-  struct stat_info tile_stat;
-  char *buf;
-  int offset, mask;
-
-  mask = METATILE - 1;
-  offset = (x & mask) * METATILE + (y & mask);
-
-  buf = read_meta_data(store, xmlconfig, options, x, y, z);
-  if (buf == NULL) {
-    tile_stat.size = -1;
-    tile_stat.expired = 0;
-    tile_stat.mtime = 0;
-    tile_stat.atime = 0;
-    tile_stat.ctime = 0;
     return tile_stat;
-  }
-
-  memcpy(&tile_stat, buf, sizeof(struct stat_info));
-  tile_stat.size = ((struct meta_layout *)(buf + sizeof(struct stat_info)))
-                       ->index[offset]
-                       .size;
-
-  return tile_stat;
 }
 
-static char *rados_tile_storage_id(struct storage_backend *store,
-                                   const char *xmlconfig, const char *options,
-                                   int x, int y, int z, char *string) {
-  char meta_path[PATH_MAX];
 
-  rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-  snprintf(string, PATH_MAX - 1, "rados://%s/%s",
-           ((struct rados_ctx *)(store->storage_ctx))->pool, meta_path);
-  return string;
+static char * rados_tile_storage_id(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string) {
+    char meta_path[PATH_MAX];
+
+    rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
+    snprintf(string,PATH_MAX - 1, "rados://%s/%s", ((struct rados_ctx *) (store->storage_ctx))->pool, meta_path);
+    return string;
 }
 
-static int rados_metatile_write(struct storage_backend *store,
-                                const char *xmlconfig, const char *options,
-                                int x, int y, int z, const char *buf, int sz) {
-  char meta_path[PATH_MAX];
-  char tmp[PATH_MAX];
-  struct stat_info tile_stat;
-  int sz2 = sz + sizeof(struct stat_info);
-  char *buf2 = malloc(sz2);
-  int err;
+static int rados_metatile_write(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz) {
+    char meta_path[PATH_MAX];
+    char tmp[PATH_MAX];
+    struct stat_info tile_stat;
+    int sz2 = sz + sizeof(struct stat_info);
+    char * buf2 = malloc(sz2);
+    int err;
 
-  tile_stat.expired = 0;
-  tile_stat.size = sz;
-  tile_stat.mtime = time(NULL);
-  tile_stat.atime = tile_stat.mtime;
-  tile_stat.ctime = tile_stat.mtime;
+    tile_stat.expired = 0;
+    tile_stat.size = sz;
+    tile_stat.mtime = time(NULL);
+    tile_stat.atime = tile_stat.mtime;
+    tile_stat.ctime = tile_stat.mtime;
 
-  memcpy(buf2, &tile_stat, sizeof(tile_stat));
-  memcpy(buf2 + sizeof(tile_stat), buf, sz);
+    memcpy(buf2, &tile_stat, sizeof(tile_stat));
+    memcpy(buf2 + sizeof(tile_stat), buf, sz);
 
-  rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-  log_message(STORE_LOGLVL_DEBUG, "Trying to create and write a tile to %s\n",
-              rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp));
+    rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
+    log_message(STORE_LOGLVL_DEBUG, "Trying to create and write a tile to %s\n", rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp));
 
-  err = rados_write_full(((struct rados_ctx *)store->storage_ctx)->io,
-                         meta_path, buf2, sz2);
-  if (err < 0) {
-    log_message(STORE_LOGLVL_ERR, "cannot write %s: %s\n",
-                rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp),
-                strerror(-err));
-    free(buf2);
-    return -1;
-  }
-  free(buf2);
-
-  return sz;
-}
-
-static int rados_metatile_delete(struct storage_backend *store,
-                                 const char *xmlconfig, int x, int y, int z) {
-  struct rados_ctx *ctx = (struct rados_ctx *)store->storage_ctx;
-  char meta_path[PATH_MAX];
-  char tmp[PATH_MAX];
-  int err;
-
-  // TODO: deal with options
-  const char *options = "";
-  rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-
-  err = rados_remove(ctx->io, meta_path);
-
-  if (err < 0) {
-    log_message(STORE_LOGLVL_ERR, "failed to delete %s: %s\n",
-                rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp),
-                strerror(-err));
-    return -1;
-  }
-
-  return 0;
-}
-
-static int rados_metatile_expire(struct storage_backend *store,
-                                 const char *xmlconfig, int x, int y, int z) {
-
-  struct stat_info tile_stat;
-  struct rados_ctx *ctx = (struct rados_ctx *)store->storage_ctx;
-  char meta_path[PATH_MAX];
-  char tmp[PATH_MAX];
-  int err;
-
-  // TODO: deal with options
-  const char *options = "";
-  rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
-  err = rados_read(ctx->io, meta_path, (char *)&tile_stat,
-                   sizeof(struct stat_info), 0);
-
-  if (err < 0) {
-    if (-err == ENOENT) {
-      log_message(
-          STORE_LOGLVL_DEBUG, "Tile %s does not exist, can't expire",
-          rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp));
-      return -1;
-    } else {
-      log_message(
-          STORE_LOGLVL_ERR, "Failed to read tile metadata for %s: %s",
-          rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp),
-          strerror(-err));
+    err = rados_write_full(((struct rados_ctx *)store->storage_ctx)->io, meta_path, buf2, sz2);
+    if (err < 0) {
+        log_message(STORE_LOGLVL_ERR, "cannot write %s: %s\n", rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp), strerror(-err));
+        free(buf2);
+        return -1;
     }
-    return -2;
-  }
+    free(buf2);
 
-  tile_stat.expired = 1;
-
-  err = rados_write(ctx->io, meta_path, (char *)&tile_stat,
-                    sizeof(struct stat_info), 0);
-
-  if (err < 0) {
-    log_message(STORE_LOGLVL_ERR, "failed to write expiry data for %s: %s",
-                rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp),
-                strerror(-err));
-    return -3;
-  }
-
-  return 0;
+    return sz;
 }
 
-static int rados_close_storage(struct storage_backend *store) {
-  struct rados_ctx *ctx = (struct rados_ctx *)store->storage_ctx;
 
-  rados_ioctx_destroy(ctx->io);
-  rados_shutdown(ctx->cluster);
-  log_message(STORE_LOGLVL_DEBUG, "rados_close_storage: Closed rados backend");
-  free(ctx->metadata_cache.data);
-  free(ctx->pool);
-  free(ctx);
-  return 0;
+static int rados_metatile_delete(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
+    struct rados_ctx * ctx = (struct rados_ctx *)store->storage_ctx;
+    char meta_path[PATH_MAX];
+    char tmp[PATH_MAX];
+    int err;
+
+    //TODO: deal with options
+    const char *options = "";
+    rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
+
+    err =  rados_remove(ctx->io, meta_path);
+
+    if (err < 0) {
+        log_message(STORE_LOGLVL_ERR, "failed to delete %s: %s\n", rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp), strerror(-err));
+        return -1;
+    }
+
+    return 0;
 }
 
-#endif // Have rados
+static int rados_metatile_expire(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
 
-struct storage_backend *init_storage_rados(const char *connection_string) {
+    struct stat_info tile_stat;
+    struct rados_ctx * ctx = (struct rados_ctx *)store->storage_ctx;
+    char meta_path[PATH_MAX];
+    char tmp[PATH_MAX];
+    int err;
 
-#ifndef HAVE_LIBRADOS
-  log_message(STORE_LOGLVL_ERR, "init_storage_rados: Support for rados has not "
-                                "been compiled into this program");
-  return NULL;
-#else
-  struct rados_ctx *ctx = malloc(sizeof(struct rados_ctx));
-  struct storage_backend *store = malloc(sizeof(struct storage_backend));
-  char *conf = NULL;
-  const char *tmp;
-  int err;
-  int i;
+    //TODO: deal with options
+    const char *options = "";
+    rados_xyzo_to_storagekey(xmlconfig, options, x, y, z, meta_path);
+    err = rados_read(ctx->io, meta_path, (char *)&tile_stat, sizeof(struct stat_info), 0);
 
-  if (ctx == NULL) {
-    return NULL;
-  }
+    if (err < 0) {
+        if (-err == ENOENT) {
+            log_message(STORE_LOGLVL_DEBUG, "Tile %s does not exist, can't expire", rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp));
+            return -1;
+        } else {
+            log_message(STORE_LOGLVL_ERR, "Failed to read tile metadata for %s: %s", rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp), strerror(-err));
+        }
+        return -2;
+    }
 
-  tmp = &(connection_string[strlen("rados://")]);
-  i = 0;
-  while ((tmp[i] != '/') && (tmp[i] != 0))
-    i++;
-  ctx->pool = calloc(i + 1, sizeof(char));
-  memcpy(ctx->pool, tmp, i * sizeof(char));
-  conf = strdup(&(tmp[i]));
+    tile_stat.expired = 1;
 
-  err = rados_create(&(ctx->cluster), NULL);
-  if (err < 0) {
-    log_message(STORE_LOGLVL_ERR,
-                "init_storage_rados: cannot create a cluster handle: %s",
-                strerror(-err));
-    free(ctx);
-    free(store);
-    return NULL;
-  }
+    err = rados_write(ctx->io, meta_path, (char *)&tile_stat, sizeof(struct stat_info), 0);
 
-  err = rados_conf_read_file(ctx->cluster, conf);
-  if (err < 0) {
-    log_message(STORE_LOGLVL_ERR,
-                "init_storage_rados: failed to read rados config file %s: %s",
-                conf, strerror(-err));
-    free(ctx);
-    free(store);
-    return NULL;
-  }
-  pthread_mutex_lock(&qLock);
-  err = rados_connect(ctx->cluster);
-  pthread_mutex_unlock(&qLock);
-  if (err < 0) {
-    log_message(STORE_LOGLVL_ERR,
-                "init_storage_rados: failed to connect to rados cluster: %s",
-                strerror(-err));
-    free(ctx);
-    free(store);
-    return NULL;
-  }
+    if (err < 0) {
+        log_message(STORE_LOGLVL_ERR, "failed to write expiry data for %s: %s", rados_tile_storage_id(store, xmlconfig, options, x, y, z, tmp), strerror(-err));
+        return -3;
+    }
 
-  err = rados_ioctx_create(ctx->cluster, ctx->pool, &(ctx->io));
-  if (err < 0) {
-    log_message(STORE_LOGLVL_ERR,
-                "init_storage_rados: failed to initialise rados io context to "
-                "pool %s: %s",
-                ctx->pool, strerror(-err));
-    rados_shutdown(ctx->cluster);
-    free(ctx);
-    free(store);
-    return NULL;
-  }
+    return 0;
+}
 
-  log_message(STORE_LOGLVL_DEBUG,
-              "init_storage_rados: Initialised rados backend for pool %s with "
-              "config %s",
-              ctx->pool, conf);
 
-  ctx->metadata_cache.data =
-      malloc(sizeof(struct stat_info) + sizeof(struct meta_layout) +
-             METATILE * METATILE * sizeof(struct entry));
-  if (ctx->metadata_cache.data == NULL) {
+static int rados_close_storage(struct storage_backend * store) {
+    struct rados_ctx * ctx = (struct rados_ctx *)store->storage_ctx;
+
     rados_ioctx_destroy(ctx->io);
     rados_shutdown(ctx->cluster);
+    log_message(STORE_LOGLVL_DEBUG,"rados_close_storage: Closed rados backend");
+    free(ctx->metadata_cache.data);
+    free(ctx->pool);
     free(ctx);
-    free(store);
+    return 0;
+}
+
+
+#endif //Have rados
+
+
+
+struct storage_backend * init_storage_rados(const char * connection_string) {
+    
+#ifndef HAVE_LIBRADOS
+    log_message(STORE_LOGLVL_ERR,"init_storage_rados: Support for rados has not been compiled into this program");
     return NULL;
-  }
+#else
+    struct rados_ctx * ctx = malloc(sizeof(struct rados_ctx));
+    struct storage_backend * store = malloc(sizeof(struct storage_backend));
+    char * conf = NULL;
+    const char * tmp;
+    int err;
+    int i;
 
-  free(conf);
+    if (ctx == NULL) {
+        return NULL;
+    }
 
-  ctx->metadata_cache.x = -1;
-  ctx->metadata_cache.y = -1;
-  ctx->metadata_cache.z = -1;
-  ctx->metadata_cache.xmlname[0] = 0;
+    tmp = &(connection_string[strlen("rados://")]);
+    i = 0;
+    while ((tmp[i] != '/') && (tmp[i] != 0)) i++;
+    ctx->pool = calloc(i + 1, sizeof(char));
+    memcpy(ctx->pool, tmp, i*sizeof(char));
+    conf = strdup(&(tmp[i]));
 
-  store->storage_ctx = ctx;
+    err = rados_create(&(ctx->cluster), NULL);
+    if (err < 0) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_rados: cannot create a cluster handle: %s", strerror(-err));
+        free(ctx);
+        free(store);
+        return NULL;
+    }
 
-  store->tile_read = &rados_tile_read;
-  store->tile_stat = &rados_tile_stat;
-  store->metatile_write = &rados_metatile_write;
-  store->metatile_delete = &rados_metatile_delete;
-  store->metatile_expire = &rados_metatile_expire;
-  store->tile_storage_id = &rados_tile_storage_id;
-  store->close_storage = &rados_close_storage;
+    err = rados_conf_read_file(ctx->cluster, conf);
+    if (err < 0) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_rados: failed to read rados config file %s: %s", conf, strerror(-err));
+        free(ctx);
+        free(store);
+        return NULL;
+    }
+    pthread_mutex_lock(&qLock);
+    err = rados_connect(ctx->cluster);
+    pthread_mutex_unlock(&qLock);
+    if (err < 0) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_rados: failed to connect to rados cluster: %s", strerror(-err));
+        free(ctx);
+        free(store);
+        return NULL;
+    }
 
-  return store;
+    err = rados_ioctx_create(ctx->cluster, ctx->pool, &(ctx->io));
+    if (err < 0) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_rados: failed to initialise rados io context to pool %s: %s", ctx->pool, strerror(-err));
+        rados_shutdown(ctx->cluster);
+        free(ctx);
+        free(store);
+        return NULL;
+    }
+
+    log_message(STORE_LOGLVL_DEBUG,"init_storage_rados: Initialised rados backend for pool %s with config %s", ctx->pool, conf);
+
+    ctx->metadata_cache.data = malloc(sizeof(struct stat_info) + sizeof(struct meta_layout) + METATILE*METATILE*sizeof(struct entry));
+    if (ctx->metadata_cache.data == NULL) {
+        rados_ioctx_destroy(ctx->io);
+        rados_shutdown(ctx->cluster);
+        free(ctx);
+        free(store);
+        return NULL;
+    }
+
+    free(conf);
+
+    ctx->metadata_cache.x = -1;
+    ctx->metadata_cache.y = -1;
+    ctx->metadata_cache.z = -1;
+    ctx->metadata_cache.xmlname[0] = 0;
+
+
+    store->storage_ctx = ctx;
+
+    store->tile_read = &rados_tile_read;
+    store->tile_stat = &rados_tile_stat;
+    store->metatile_write = &rados_metatile_write;
+    store->metatile_delete = &rados_metatile_delete;
+    store->metatile_expire = &rados_metatile_expire;
+    store->tile_storage_id = &rados_tile_storage_id;
+    store->close_storage = &rados_close_storage;
+
+    return store;
 #endif
 }

--- a/src/store_ro_composite.c
+++ b/src/store_ro_composite.c
@@ -1,10 +1,10 @@
 #include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
+#include <string.h>
 
-// TODO: need to create an appropriate configure check.
+//TODO: need to create an appropriate configure check.
 #ifdef HAVE_CAIRO
 #define WANT_STORE_COMPOSITE
 #endif
@@ -13,307 +13,242 @@
 #include <cairo/cairo.h>
 #endif
 
-#include "protocol.h"
-#include "render_config.h"
 #include "store.h"
 #include "store_ro_composite.h"
+#include "render_config.h"
+#include "protocol.h"
+
 
 #ifdef WANT_STORE_COMPOSITE
 
 struct tile_cache {
-  struct stat_info st_stat;
-  char *tile;
-  int x, y, z;
-  char xmlname[XMLCONFIG_MAX];
+    struct stat_info st_stat;
+    char * tile;
+    int x,y,z;
+    char xmlname[XMLCONFIG_MAX];
 };
 
 struct ro_composite_ctx {
-  struct storage_backend *store_primary;
-  char xmlconfig_primary[XMLCONFIG_MAX];
-  struct storage_backend *store_secondary;
-  char xmlconfig_secondary[XMLCONFIG_MAX];
-  struct tile_cache cache;
-  int render_size;
+    struct storage_backend * store_primary;
+    char xmlconfig_primary[XMLCONFIG_MAX];
+    struct storage_backend * store_secondary;
+    char xmlconfig_secondary[XMLCONFIG_MAX];
+    struct tile_cache cache;
+    int render_size;
 };
 
-typedef struct {
-  char *data;
-  unsigned int max_size;
-  unsigned int pos;
+typedef struct
+{
+    char *data;
+    unsigned int max_size;
+    unsigned int pos;
 } png_stream_to_byte_array_closure_t;
 
-static cairo_status_t write_png_stream_to_byte_array(void *in_closure,
-                                                     const unsigned char *data,
-                                                     unsigned int length) {
-  png_stream_to_byte_array_closure_t *closure =
-      (png_stream_to_byte_array_closure_t *)in_closure;
+static cairo_status_t write_png_stream_to_byte_array (void *in_closure, const unsigned char *data, unsigned int length)
+{
+    png_stream_to_byte_array_closure_t *closure = (png_stream_to_byte_array_closure_t *) in_closure;
 
-  // log_message(STORE_LOGLVL_DEBUG, "ro_composite_tile: writing to byte array:
-  // pos: %i, length: %i", closure->pos, length);
+    //log_message(STORE_LOGLVL_DEBUG, "ro_composite_tile: writing to byte array: pos: %i, length: %i", closure->pos, length);
 
-  if ((closure->pos + length) > (closure->max_size))
-    return CAIRO_STATUS_WRITE_ERROR;
+    if ((closure->pos + length) > (closure->max_size))
+        return CAIRO_STATUS_WRITE_ERROR;
 
-  memcpy((closure->data + closure->pos), data, length);
-  closure->pos += length;
+    memcpy ((closure->data + closure->pos), data, length);
+    closure->pos += length;
 
-  return CAIRO_STATUS_SUCCESS;
+    return CAIRO_STATUS_SUCCESS;
 }
 
-static cairo_status_t read_png_stream_from_byte_array(void *in_closure,
-                                                      unsigned char *data,
-                                                      unsigned int length) {
-  png_stream_to_byte_array_closure_t *closure =
-      (png_stream_to_byte_array_closure_t *)in_closure;
+static cairo_status_t read_png_stream_from_byte_array (void *in_closure, unsigned char *data, unsigned int length)
+{
+    png_stream_to_byte_array_closure_t *closure =  (png_stream_to_byte_array_closure_t *) in_closure;
 
-  // log_message(STORE_LOGLVL_DEBUG, "ro_composite_tile: reading from byte
-  // array: pos: %i, length: %i", closure->pos, length);
+    //log_message(STORE_LOGLVL_DEBUG, "ro_composite_tile: reading from byte array: pos: %i, length: %i", closure->pos, length);
 
-  if ((closure->pos + length) > (closure->max_size))
-    return CAIRO_STATUS_READ_ERROR;
+    if ((closure->pos + length) > (closure->max_size))
+        return CAIRO_STATUS_READ_ERROR;
 
-  memcpy(data, (closure->data + closure->pos), length);
-  closure->pos += length;
+    memcpy (data, (closure->data + closure->pos), length);
+    closure->pos += length;
 
-  return CAIRO_STATUS_SUCCESS;
+    return CAIRO_STATUS_SUCCESS;
 }
 
-static int ro_composite_tile_read(struct storage_backend *store,
-                                  const char *xmlconfig, const char *options,
-                                  int x, int y, int z, char *buf, size_t sz,
-                                  int *compressed, char *log_msg) {
-  struct ro_composite_ctx *ctx =
-      (struct ro_composite_ctx *)(store->storage_ctx);
-  cairo_surface_t *imageA;
-  cairo_surface_t *imageB;
-  cairo_surface_t *imageC;
-  cairo_t *cr;
-  png_stream_to_byte_array_closure_t closure;
 
-  if (ctx->store_primary->tile_read(ctx->store_primary, ctx->xmlconfig_primary,
-                                    options, x, y, z, buf, sz, compressed,
-                                    log_msg) < 0) {
-    snprintf(log_msg, 1024,
-             "ro_composite_tile_read: Failed to read tile data of primary "
-             "backend\n");
-    return -1;
-  }
-  closure.data = buf;
-  closure.pos = 0;
-  closure.max_size = sz;
-  imageA = cairo_image_surface_create_from_png_stream(
-      &read_png_stream_from_byte_array, &closure);
-  if (!imageA) {
-    snprintf(log_msg, 1024,
-             "ro_composite_tile_read: Failed to decode png data from primary "
-             "backend\n");
-    return -1;
-  }
+static int ro_composite_tile_read(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg) {
+    struct ro_composite_ctx * ctx = (struct ro_composite_ctx *)(store->storage_ctx);
+    cairo_surface_t *imageA;
+    cairo_surface_t *imageB;
+    cairo_surface_t *imageC;
+    cairo_t *cr;
+    png_stream_to_byte_array_closure_t closure;
 
-  if (ctx->store_secondary->tile_read(ctx->store_secondary,
-                                      ctx->xmlconfig_secondary, options, x, y,
-                                      z, buf, sz, compressed, log_msg) < 0) {
-    snprintf(log_msg, 1024,
-             "ro_composite_tile_read: Failed to read tile data of secondary "
-             "backend\n");
-    cairo_surface_destroy(imageA);
-    return -1;
-  }
-  closure.data = buf;
-  closure.pos = 0;
-  closure.max_size = sz;
-  imageB = cairo_image_surface_create_from_png_stream(
-      &read_png_stream_from_byte_array, &closure);
-  if (!imageB) {
-    snprintf(log_msg, 1024,
-             "ro_composite_tile_read: Failed to decode png data from secondary "
-             "backend\n");
-    cairo_surface_destroy(imageA);
-    return -1;
-  }
+    if(ctx->store_primary->tile_read(ctx->store_primary, ctx->xmlconfig_primary, options, x, y, z, buf, sz, compressed, log_msg) < 0) {
+        snprintf(log_msg,1024, "ro_composite_tile_read: Failed to read tile data of primary backend\n");
+        return -1;
+    }
+    closure.data = buf;
+    closure.pos = 0;
+    closure.max_size = sz;
+    imageA = cairo_image_surface_create_from_png_stream(&read_png_stream_from_byte_array, &closure);
+    if (!imageA) {
+        snprintf(log_msg,1024, "ro_composite_tile_read: Failed to decode png data from primary backend\n");
+        return -1;
+    }
 
-  imageC = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, ctx->render_size,
-                                      ctx->render_size);
-  if (!imageC) {
-    snprintf(log_msg, 1024,
-             "ro_composite_tile_read: Failed to create output png\n");
+    if(ctx->store_secondary->tile_read(ctx->store_secondary, ctx->xmlconfig_secondary, options, x, y, z, buf, sz, compressed, log_msg) < 0) {
+        snprintf(log_msg,1024, "ro_composite_tile_read: Failed to read tile data of secondary backend\n");
+        cairo_surface_destroy(imageA);
+        return -1;
+    }
+    closure.data = buf;
+    closure.pos = 0;
+    closure.max_size = sz;
+    imageB = cairo_image_surface_create_from_png_stream(&read_png_stream_from_byte_array, &closure);
+    if (!imageB) {
+        snprintf(log_msg,1024, "ro_composite_tile_read: Failed to decode png data from secondary backend\n");
+        cairo_surface_destroy(imageA);
+        return -1;
+    }
+
+    imageC = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, ctx->render_size, ctx->render_size);
+    if (!imageC) {
+        snprintf(log_msg,1024, "ro_composite_tile_read: Failed to create output png\n");
+        cairo_surface_destroy(imageA);
+        cairo_surface_destroy(imageB);
+        return -1;
+    }
+
+    //Create the cairo context
+    cr = cairo_create(imageC);
+    cairo_set_source_surface(cr, imageA, 0, 0);
+    cairo_paint(cr);
+    cairo_set_source_surface(cr, imageB, 0, 0);
+    cairo_paint(cr);
+    cairo_surface_flush(imageC);
+    cairo_destroy(cr);
+
+    closure.data = buf;
+    closure.pos = 0;
+    closure.max_size = sz;
+    cairo_surface_write_to_png_stream(imageC, &write_png_stream_to_byte_array, &closure);
+
     cairo_surface_destroy(imageA);
     cairo_surface_destroy(imageB);
+    cairo_surface_destroy(imageC);
+
+    return closure.pos;
+}
+
+static struct stat_info ro_composite_tile_stat(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z) {
+    struct ro_composite_ctx * ctx = (struct ro_composite_ctx *)(store->storage_ctx);
+    return ctx->store_primary->tile_stat(ctx->store_primary,ctx->xmlconfig_primary, options, x, y, z);
+}
+
+
+static char * ro_composite_tile_storage_id(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string) {
+
+    return "Coposite tile";
+}
+
+static int ro_composite_metatile_write(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz) {
+    log_message(STORE_LOGLVL_ERR, "ro_composite_metatile_write: This is a readonly storage backend. Write functionality isn't implemented");
     return -1;
-  }
-
-  // Create the cairo context
-  cr = cairo_create(imageC);
-  cairo_set_source_surface(cr, imageA, 0, 0);
-  cairo_paint(cr);
-  cairo_set_source_surface(cr, imageB, 0, 0);
-  cairo_paint(cr);
-  cairo_surface_flush(imageC);
-  cairo_destroy(cr);
-
-  closure.data = buf;
-  closure.pos = 0;
-  closure.max_size = sz;
-  cairo_surface_write_to_png_stream(imageC, &write_png_stream_to_byte_array,
-                                    &closure);
-
-  cairo_surface_destroy(imageA);
-  cairo_surface_destroy(imageB);
-  cairo_surface_destroy(imageC);
-
-  return closure.pos;
 }
 
-static struct stat_info ro_composite_tile_stat(struct storage_backend *store,
-                                               const char *xmlconfig,
-                                               const char *options, int x,
-                                               int y, int z) {
-  struct ro_composite_ctx *ctx =
-      (struct ro_composite_ctx *)(store->storage_ctx);
-  return ctx->store_primary->tile_stat(
-      ctx->store_primary, ctx->xmlconfig_primary, options, x, y, z);
+
+static int ro_composite_metatile_delete(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
+    log_message(STORE_LOGLVL_ERR, "ro_composite_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
+    return -1;
 }
 
-static char *ro_composite_tile_storage_id(struct storage_backend *store,
-                                          const char *xmlconfig,
-                                          const char *options, int x, int y,
-                                          int z, char *string) {
+static int ro_composite_metatile_expire(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
 
-  return "Coposite tile";
+    log_message(STORE_LOGLVL_ERR, "ro_composite_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
+    return -1;
 }
 
-static int ro_composite_metatile_write(struct storage_backend *store,
-                                       const char *xmlconfig,
-                                       const char *options, int x, int y, int z,
-                                       const char *buf, int sz) {
-  log_message(STORE_LOGLVL_ERR,
-              "ro_composite_metatile_write: This is a readonly storage "
-              "backend. Write functionality isn't implemented");
-  return -1;
-}
 
-static int ro_composite_metatile_delete(struct storage_backend *store,
-                                        const char *xmlconfig, int x, int y,
-                                        int z) {
-  log_message(STORE_LOGLVL_ERR,
-              "ro_composite_metatile_expire: This is a readonly storage "
-              "backend. Write functionality isn't implemented");
-  return -1;
-}
-
-static int ro_composite_metatile_expire(struct storage_backend *store,
-                                        const char *xmlconfig, int x, int y,
-                                        int z) {
-
-  log_message(STORE_LOGLVL_ERR,
-              "ro_composite_metatile_expire: This is a readonly storage "
-              "backend. Write functionality isn't implemented");
-  return -1;
-}
-
-static int ro_composite_close_storage(struct storage_backend *store) {
-  struct ro_composite_ctx *ctx =
-      (struct ro_composite_ctx *)(store->storage_ctx);
-  ctx->store_primary->close_storage(ctx->store_primary);
-  ctx->store_secondary->close_storage(ctx->store_secondary);
-  if (ctx->cache.tile)
-    free(ctx->cache.tile);
-  free(ctx);
-  free(store);
-  return 0;
-}
-
-#endif // WANT_COMPOSITE
-
-struct storage_backend *
-init_storage_ro_composite(const char *connection_string) {
-
-#ifndef WANT_STORE_COMPOSITE
-  log_message(STORE_LOGLVL_ERR,
-              "init_storage_ro_coposite: Support for compositing storage has "
-              "not been compiled into this program");
-  return NULL;
-#else
-  struct storage_backend *store = malloc(sizeof(struct storage_backend));
-  struct ro_composite_ctx *ctx = malloc(sizeof(struct ro_composite_ctx));
-  char *connection_string_primary;
-  char *connection_string_secondary;
-  char *tmp;
-
-  log_message(STORE_LOGLVL_DEBUG,
-              "init_storage_ro_composite: initialising compositing storage "
-              "backend for %s",
-              connection_string);
-
-  if (!store || !ctx) {
-    log_message(
-        STORE_LOGLVL_ERR,
-        "init_storage_ro_composite: failed to allocate memory for context");
-    if (store)
-      free(store);
-    if (ctx)
-      free(ctx);
-    return NULL;
-  }
-
-  connection_string_secondary = strstr(connection_string, "}{");
-  connection_string_primary =
-      malloc(strlen(connection_string) - strlen("composite:{") -
-             strlen(connection_string_secondary) + 1);
-  memcpy(connection_string_primary, connection_string + strlen("composite:{"),
-         strlen(connection_string) - strlen("composite:{") -
-             strlen(connection_string_secondary));
-  connection_string_primary[strlen(connection_string) - strlen("composite:{") -
-                            strlen(connection_string_secondary)] = 0;
-  connection_string_secondary = strdup(connection_string_secondary + 2);
-  connection_string_secondary[strlen(connection_string_secondary) - 1] = 0;
-
-  log_message(STORE_LOGLVL_DEBUG,
-              "init_storage_ro_composite: Primary storage backend: %s",
-              connection_string_primary);
-  log_message(STORE_LOGLVL_DEBUG,
-              "init_storage_ro_composite: Secondary storage backend: %s",
-              connection_string_secondary);
-
-  tmp = strstr(connection_string_primary, ",");
-  memcpy(ctx->xmlconfig_primary, connection_string_primary,
-         tmp - connection_string_primary);
-  ctx->xmlconfig_primary[tmp - connection_string_primary] = 0;
-  ctx->store_primary = init_storage_backend(tmp + 1);
-  if (ctx->store_primary == NULL) {
-    log_message(STORE_LOGLVL_ERR, "init_storage_ro_composite: failed to "
-                                  "initialise primary storage backend");
-    free(ctx);
-    free(store);
-    return NULL;
-  }
-
-  tmp = strstr(connection_string_secondary, ",");
-  memcpy(ctx->xmlconfig_secondary, connection_string_secondary,
-         tmp - connection_string_secondary);
-  ctx->xmlconfig_secondary[tmp - connection_string_secondary] = 0;
-  ctx->store_secondary = init_storage_backend(tmp + 1);
-  if (ctx->store_secondary == NULL) {
-    log_message(STORE_LOGLVL_ERR, "init_storage_ro_composite: failed to "
-                                  "initialise secondary storage backend");
+static int ro_composite_close_storage(struct storage_backend * store) {
+    struct ro_composite_ctx * ctx = (struct ro_composite_ctx *)(store->storage_ctx);
     ctx->store_primary->close_storage(ctx->store_primary);
+    ctx->store_secondary->close_storage(ctx->store_secondary);
+    if(ctx->cache.tile) free(ctx->cache.tile);
     free(ctx);
     free(store);
+    return 0;
+}
+
+#endif //WANT_COMPOSITE
+
+
+
+struct storage_backend * init_storage_ro_composite(const char * connection_string) {
+    
+#ifndef WANT_STORE_COMPOSITE
+    log_message(STORE_LOGLVL_ERR,"init_storage_ro_coposite: Support for compositing storage has not been compiled into this program");
     return NULL;
-  }
+#else
+    struct storage_backend * store = malloc(sizeof(struct storage_backend));
+    struct ro_composite_ctx * ctx = malloc(sizeof(struct ro_composite_ctx));
+    char * connection_string_primary;
+    char * connection_string_secondary;
+    char * tmp;
 
-  ctx->render_size = 256;
+    log_message(STORE_LOGLVL_DEBUG,"init_storage_ro_composite: initialising compositing storage backend for %s", connection_string);
 
-  store->storage_ctx = ctx;
+    if (!store || !ctx) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_ro_composite: failed to allocate memory for context");
+        if (store) free(store);
+        if (ctx) free(ctx);
+        return NULL;
+    }
 
-  store->tile_read = &ro_composite_tile_read;
-  store->tile_stat = &ro_composite_tile_stat;
-  store->metatile_write = &ro_composite_metatile_write;
-  store->metatile_delete = &ro_composite_metatile_delete;
-  store->metatile_expire = &ro_composite_metatile_expire;
-  store->tile_storage_id = &ro_composite_tile_storage_id;
-  store->close_storage = &ro_composite_close_storage;
+    connection_string_secondary = strstr(connection_string,"}{");
+    connection_string_primary = malloc(strlen(connection_string) - strlen("composite:{") - strlen(connection_string_secondary) + 1);
+    memcpy(connection_string_primary,connection_string + strlen("composite:{"), strlen(connection_string) - strlen("composite:{") - strlen(connection_string_secondary));
+    connection_string_primary[strlen(connection_string) - strlen("composite:{") - strlen(connection_string_secondary)] = 0;
+    connection_string_secondary = strdup(connection_string_secondary + 2);
+    connection_string_secondary[strlen(connection_string_secondary) - 1] = 0;
 
-  return store;
+    log_message(STORE_LOGLVL_DEBUG,"init_storage_ro_composite: Primary storage backend: %s", connection_string_primary);
+    log_message(STORE_LOGLVL_DEBUG,"init_storage_ro_composite: Secondary storage backend: %s", connection_string_secondary);
+
+    tmp = strstr(connection_string_primary, ",");
+    memcpy(ctx->xmlconfig_primary, connection_string_primary, tmp - connection_string_primary);
+    ctx->xmlconfig_primary[tmp - connection_string_primary] = 0;
+    ctx->store_primary = init_storage_backend(tmp + 1);
+    if (ctx->store_primary == NULL) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_ro_composite: failed to initialise primary storage backend");
+        free(ctx);
+        free(store);
+        return NULL;
+    }
+
+    tmp = strstr(connection_string_secondary, ",");
+    memcpy(ctx->xmlconfig_secondary, connection_string_secondary, tmp - connection_string_secondary);
+    ctx->xmlconfig_secondary[tmp - connection_string_secondary] = 0;
+    ctx->store_secondary = init_storage_backend(tmp + 1);
+    if (ctx->store_secondary == NULL) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_ro_composite: failed to initialise secondary storage backend");
+        ctx->store_primary->close_storage(ctx->store_primary);
+        free(ctx);
+        free(store);
+        return NULL;
+    }
+
+    ctx->render_size = 256;
+
+    store->storage_ctx = ctx;
+
+    store->tile_read = &ro_composite_tile_read;
+    store->tile_stat = &ro_composite_tile_stat;
+    store->metatile_write = &ro_composite_metatile_write;
+    store->metatile_delete = &ro_composite_metatile_delete;
+    store->metatile_expire = &ro_composite_metatile_expire;
+    store->tile_storage_id = &ro_composite_tile_storage_id;
+    store->close_storage = &ro_composite_close_storage;
+
+    return store;
 #endif
 }

--- a/src/store_ro_http_proxy.c
+++ b/src/store_ro_http_proxy.c
@@ -1,21 +1,22 @@
 #include "config.h"
-#include <limits.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
 #include <string.h>
 #include <sys/types.h>
-#include <unistd.h>
+#include <pthread.h>
 
 #ifdef HAVE_LIBCURL
 #include <curl/curl.h>
 #include <curl/easy.h>
 #endif
 
-#include "protocol.h"
-#include "render_config.h"
 #include "store.h"
 #include "store_ro_http_proxy.h"
+#include "render_config.h"
+#include "protocol.h"
+
 
 #ifdef HAVE_LIBCURL
 
@@ -23,34 +24,33 @@ static pthread_mutex_t qLock;
 static int done_global_init = 0;
 
 struct tile_cache {
-  struct stat_info st_stat;
-  char *tile;
-  int x, y, z;
-  char xmlname[XMLCONFIG_MAX];
+    struct stat_info st_stat;
+    char * tile;
+    int x,y,z;
+    char xmlname[XMLCONFIG_MAX];
 };
 
 struct ro_http_proxy_ctx {
-  CURL *ctx;
-  char *baseurl;
-  struct tile_cache cache;
+    CURL * ctx;
+    char * baseurl;
+    struct tile_cache cache;
 };
 
 struct MemoryStruct {
-  char *memory;
-  size_t size;
+    char *memory;
+    size_t size;
 };
 
-static size_t write_memory_callback(void *contents, size_t size, size_t nmemb,
-                                    void *userp) {
+
+static size_t write_memory_callback(void *contents, size_t size, size_t nmemb, void *userp) {
   size_t realsize = size * nmemb;
-  struct MemoryStruct *chunk = userp;
+  struct MemoryStruct * chunk = userp;
   if (chunk->memory) {
-    chunk->memory = realloc(chunk->memory, chunk->size + realsize);
+      chunk->memory = realloc(chunk->memory, chunk->size + realsize);
   } else {
-    chunk->memory = malloc(realsize);
+      chunk->memory = malloc(realsize);
   }
-  // log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_read: writing a chunk:
-  // Position %i, size %i", chunk->size, realsize);
+  //log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_read: writing a chunk: Position %i, size %i", chunk->size, realsize);
 
   memcpy(&(chunk->memory[chunk->size]), contents, realsize);
   chunk->size += realsize;
@@ -58,278 +58,214 @@ static size_t write_memory_callback(void *contents, size_t size, size_t nmemb,
   return realsize;
 }
 
-static char *ro_http_proxy_xyz_to_storagekey(struct storage_backend *store,
-                                             int x, int y, int z, char *key) {
-  snprintf(key, PATH_MAX - 1, "http://%s/%i/%i/%i.png",
-           ((struct ro_http_proxy_ctx *)(store->storage_ctx))->baseurl, z, x,
-           y);
-  return key;
+static char * ro_http_proxy_xyz_to_storagekey(struct storage_backend * store, int x, int y, int z, char * key) {
+    snprintf(key,PATH_MAX - 1, "http://%s/%i/%i/%i.png", ((struct ro_http_proxy_ctx *) (store->storage_ctx))->baseurl, z, x, y);
+    return key;
 }
 
-static int ro_http_proxy_tile_retrieve(struct storage_backend *store,
-                                       const char *xmlconfig,
-                                       const char *options, int x, int y,
-                                       int z) {
-  struct ro_http_proxy_ctx *ctx =
-      (struct ro_http_proxy_ctx *)(store->storage_ctx);
-  char *path;
-  CURLcode res;
-  struct MemoryStruct chunk;
-  long httpCode;
+static int ro_http_proxy_tile_retrieve(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z) {
+    struct ro_http_proxy_ctx * ctx = (struct ro_http_proxy_ctx *)(store->storage_ctx);
+    char * path;
+    CURLcode res;
+    struct MemoryStruct chunk;
+    long httpCode;
 
-  // TODO: Deal with options
-  if ((ctx->cache.x == x) && (ctx->cache.y == y) && (ctx->cache.z == z) &&
-      (strcmp(ctx->cache.xmlname, xmlconfig) == 0)) {
-    log_message(STORE_LOGLVL_DEBUG,
-                "ro_http_proxy_tile_fetch: Got a cached tile");
-    return 1;
-  } else {
-    log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_fetch: Fetching tile");
+    //TODO: Deal with options
+    if ((ctx->cache.x == x) && (ctx->cache.y == y) && (ctx->cache.z == z) && (strcmp(ctx->cache.xmlname, xmlconfig) == 0)) {
+        log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_fetch: Got a cached tile");
+        return 1;
+    } else {
+        log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_fetch: Fetching tile");
 
-    chunk.memory = NULL;
-    chunk.size = 0;
-    path = malloc(PATH_MAX);
+        chunk.memory = NULL;
+        chunk.size = 0;
+        path = malloc(PATH_MAX);
 
-    ro_http_proxy_xyz_to_storagekey(store, x, y, z, path);
-    log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_fetch: proxing file %s",
-                path);
-    curl_easy_setopt(ctx->ctx, CURLOPT_URL, path);
+        ro_http_proxy_xyz_to_storagekey(store, x, y, z, path);
+        log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_fetch: proxing file %s", path);
+        curl_easy_setopt(ctx->ctx, CURLOPT_URL, path);
 
-    curl_easy_setopt(ctx->ctx, CURLOPT_WRITEFUNCTION, write_memory_callback);
-    curl_easy_setopt(ctx->ctx, CURLOPT_WRITEDATA, (void *)&chunk);
+        curl_easy_setopt(ctx->ctx, CURLOPT_WRITEFUNCTION, write_memory_callback);
+        curl_easy_setopt(ctx->ctx, CURLOPT_WRITEDATA, (void *)&chunk);
 
-    res = curl_easy_perform(ctx->ctx);
-    free(path);
+        res = curl_easy_perform(ctx->ctx);
+        free(path);
 
-    if (res != CURLE_OK) {
-      log_message(STORE_LOGLVL_ERR,
-                  "ro_http_proxy_tile_fetch: failed to retrieve file: %s",
-                  curl_easy_strerror(res));
-      ctx->cache.x = -1;
-      ctx->cache.y = -1;
-      ctx->cache.z = -1;
-      return -1;
+        if(res != CURLE_OK) {
+            log_message(STORE_LOGLVL_ERR, "ro_http_proxy_tile_fetch: failed to retrieve file: %s", curl_easy_strerror(res));
+            ctx->cache.x = -1;  ctx->cache.y = -1;  ctx->cache.z = -1;
+            return -1;
+        }
+
+        res = curl_easy_getinfo(ctx->ctx, CURLINFO_RESPONSE_CODE, &httpCode );
+        if (res != CURLE_OK) {
+            log_message(STORE_LOGLVL_ERR, "ro_http_proxy_tile_fetch: failed to retrieve HTTP code: %s", curl_easy_strerror(res));
+            ctx->cache.x = -1;  ctx->cache.y = -1;  ctx->cache.z = -1;
+            return -1;
+        }
+
+        switch (httpCode) {
+        case 200: {
+            if (ctx->cache.tile != NULL) free(ctx->cache.tile);
+            ctx->cache.tile = chunk.memory;
+            ctx->cache.st_stat.size = chunk.size;
+            ctx->cache.st_stat.expired = 0;
+            res = curl_easy_getinfo(ctx->ctx, CURLINFO_FILETIME, &(ctx->cache.st_stat.mtime));
+            ctx->cache.st_stat.atime = 0;
+            log_message(STORE_LOGLVL_DEBUG, "ro_http_proxy_tile_read: Read file of size %i", chunk.size);
+            break;
+        }
+        case 404: {
+            if (ctx->cache.tile != NULL) free(ctx->cache.tile);
+            ctx->cache.st_stat.size = -1;
+            ctx->cache.st_stat.expired = 0;
+            break;
+        }
+        }
+
+
+        ctx->cache.x = x;  ctx->cache.y = y;  ctx->cache.z = z;
+        strcpy(ctx->cache.xmlname,xmlconfig);
+        return 1;
     }
-
-    res = curl_easy_getinfo(ctx->ctx, CURLINFO_RESPONSE_CODE, &httpCode);
-    if (res != CURLE_OK) {
-      log_message(STORE_LOGLVL_ERR,
-                  "ro_http_proxy_tile_fetch: failed to retrieve HTTP code: %s",
-                  curl_easy_strerror(res));
-      ctx->cache.x = -1;
-      ctx->cache.y = -1;
-      ctx->cache.z = -1;
-      return -1;
-    }
-
-    switch (httpCode) {
-    case 200: {
-      if (ctx->cache.tile != NULL)
-        free(ctx->cache.tile);
-      ctx->cache.tile = chunk.memory;
-      ctx->cache.st_stat.size = chunk.size;
-      ctx->cache.st_stat.expired = 0;
-      res = curl_easy_getinfo(ctx->ctx, CURLINFO_FILETIME,
-                              &(ctx->cache.st_stat.mtime));
-      ctx->cache.st_stat.atime = 0;
-      log_message(STORE_LOGLVL_DEBUG,
-                  "ro_http_proxy_tile_read: Read file of size %i", chunk.size);
-      break;
-    }
-    case 404: {
-      if (ctx->cache.tile != NULL)
-        free(ctx->cache.tile);
-      ctx->cache.st_stat.size = -1;
-      ctx->cache.st_stat.expired = 0;
-      break;
-    }
-    }
-
-    ctx->cache.x = x;
-    ctx->cache.y = y;
-    ctx->cache.z = z;
-    strcpy(ctx->cache.xmlname, xmlconfig);
-    return 1;
-  }
 }
 
-static int ro_http_proxy_tile_read(struct storage_backend *store,
-                                   const char *xmlconfig, const char *options,
-                                   int x, int y, int z, char *buf, size_t sz,
-                                   int *compressed, char *log_msg) {
-  struct ro_http_proxy_ctx *ctx =
-      (struct ro_http_proxy_ctx *)(store->storage_ctx);
+static int ro_http_proxy_tile_read(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg) {
+    struct ro_http_proxy_ctx * ctx = (struct ro_http_proxy_ctx *)(store->storage_ctx);
 
-  if (ro_http_proxy_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
-    if (ctx->cache.st_stat.size > sz) {
-      log_message(STORE_LOGLVL_ERR,
-                  "ro_http_proxy_tile_read: size was too big, overrun %i %i",
-                  sz, ctx->cache.st_stat.size);
-      return -1;
+    if (ro_http_proxy_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
+        if (ctx->cache.st_stat.size > sz) {
+            log_message(STORE_LOGLVL_ERR, "ro_http_proxy_tile_read: size was too big, overrun %i %i", sz, ctx->cache.st_stat.size);
+            return -1;
+        }
+        memcpy(buf, ctx->cache.tile, ctx->cache.st_stat.size);
+        return ctx->cache.st_stat.size;
+    } else {
+        log_message(STORE_LOGLVL_ERR, "ro_http_proxy_tile_read: Fetching didn't work");
+        return -1;
     }
-    memcpy(buf, ctx->cache.tile, ctx->cache.st_stat.size);
-    return ctx->cache.st_stat.size;
-  } else {
-    log_message(STORE_LOGLVL_ERR,
-                "ro_http_proxy_tile_read: Fetching didn't work");
+}
+
+static struct stat_info ro_http_proxy_tile_stat(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z) {
+    struct stat_info tile_stat;
+    struct ro_http_proxy_ctx * ctx = (struct ro_http_proxy_ctx *)(store->storage_ctx);
+
+    if (ro_http_proxy_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
+        return ctx->cache.st_stat;
+    } else {
+        tile_stat.size = -1;
+        tile_stat.expired = 0;
+        tile_stat.mtime = 0;
+        tile_stat.atime = 0;
+        tile_stat.ctime = 0;
+        return tile_stat;
+    }
+}
+
+
+static char * ro_http_proxy_tile_storage_id(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string) {
+
+    return ro_http_proxy_xyz_to_storagekey(store, x, y, z, string);
+}
+
+static int ro_http_proxy_metatile_write(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz) {
+    log_message(STORE_LOGLVL_ERR, "ro_http_proxy_metatile_write: This is a readonly storage backend. Write functionality isn't implemented");
     return -1;
-  }
 }
 
-static struct stat_info ro_http_proxy_tile_stat(struct storage_backend *store,
-                                                const char *xmlconfig,
-                                                const char *options, int x,
-                                                int y, int z) {
-  struct stat_info tile_stat;
-  struct ro_http_proxy_ctx *ctx =
-      (struct ro_http_proxy_ctx *)(store->storage_ctx);
 
-  if (ro_http_proxy_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
-    return ctx->cache.st_stat;
-  } else {
-    tile_stat.size = -1;
-    tile_stat.expired = 0;
-    tile_stat.mtime = 0;
-    tile_stat.atime = 0;
-    tile_stat.ctime = 0;
-    return tile_stat;
-  }
+static int ro_http_proxy_metatile_delete(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
+    log_message(STORE_LOGLVL_ERR, "ro_http_proxy_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
+    return -1;
 }
 
-static char *ro_http_proxy_tile_storage_id(struct storage_backend *store,
-                                           const char *xmlconfig,
-                                           const char *options, int x, int y,
-                                           int z, char *string) {
+static int ro_http_proxy_metatile_expire(struct storage_backend * store, const char *xmlconfig, int x, int y, int z) {
 
-  return ro_http_proxy_xyz_to_storagekey(store, x, y, z, string);
+    log_message(STORE_LOGLVL_ERR, "ro_http_proxy_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
+    return -1;
 }
 
-static int ro_http_proxy_metatile_write(struct storage_backend *store,
-                                        const char *xmlconfig,
-                                        const char *options, int x, int y,
-                                        int z, const char *buf, int sz) {
-  log_message(STORE_LOGLVL_ERR,
-              "ro_http_proxy_metatile_write: This is a readonly storage "
-              "backend. Write functionality isn't implemented");
-  return -1;
+
+static int ro_http_proxy_close_storage(struct storage_backend * store) {
+    struct ro_http_proxy_ctx * ctx = (struct ro_http_proxy_ctx *)(store->storage_ctx);
+
+    free(ctx->baseurl);
+    if (ctx->cache.tile) free(ctx->cache.tile);
+    curl_easy_cleanup(ctx->ctx);
+    free(ctx);
+    free(store);
+
+    return 0;
 }
 
-static int ro_http_proxy_metatile_delete(struct storage_backend *store,
-                                         const char *xmlconfig, int x, int y,
-                                         int z) {
-  log_message(STORE_LOGLVL_ERR,
-              "ro_http_proxy_metatile_expire: This is a readonly storage "
-              "backend. Write functionality isn't implemented");
-  return -1;
-}
 
-static int ro_http_proxy_metatile_expire(struct storage_backend *store,
-                                         const char *xmlconfig, int x, int y,
-                                         int z) {
+#endif //Have curl
 
-  log_message(STORE_LOGLVL_ERR,
-              "ro_http_proxy_metatile_expire: This is a readonly storage "
-              "backend. Write functionality isn't implemented");
-  return -1;
-}
 
-static int ro_http_proxy_close_storage(struct storage_backend *store) {
-  struct ro_http_proxy_ctx *ctx =
-      (struct ro_http_proxy_ctx *)(store->storage_ctx);
 
-  free(ctx->baseurl);
-  if (ctx->cache.tile)
-    free(ctx->cache.tile);
-  curl_easy_cleanup(ctx->ctx);
-  free(ctx);
-  free(store);
-
-  return 0;
-}
-
-#endif // Have curl
-
-struct storage_backend *
-init_storage_ro_http_proxy(const char *connection_string) {
-
+struct storage_backend * init_storage_ro_http_proxy(const char * connection_string) {
+    
 #ifndef HAVE_LIBCURL
-  log_message(STORE_LOGLVL_ERR,
-              "init_storage_ro_http_proxy: Support for curl and therefore the "
-              "http proxy storage has not been compiled into this program");
-  return NULL;
+    log_message(STORE_LOGLVL_ERR,"init_storage_ro_http_proxy: Support for curl and therefore the http proxy storage has not been compiled into this program");
+    return NULL;
 #else
-  struct storage_backend *store = malloc(sizeof(struct storage_backend));
-  struct ro_http_proxy_ctx *ctx = malloc(sizeof(struct ro_http_proxy_ctx));
-  CURLcode res;
+    struct storage_backend * store = malloc(sizeof(struct storage_backend));
+    struct ro_http_proxy_ctx * ctx = malloc(sizeof(struct ro_http_proxy_ctx));
+    CURLcode res;
 
-  log_message(
-      STORE_LOGLVL_DEBUG,
-      "init_storage_ro_http_proxy: initialising proxy storage backend for %s",
-      connection_string);
+    log_message(STORE_LOGLVL_DEBUG,"init_storage_ro_http_proxy: initialising proxy storage backend for %s", connection_string);
 
-  if (!store || !ctx) {
-    log_message(
-        STORE_LOGLVL_ERR,
-        "init_storage_ro_http_proxy: failed to allocate memory for context");
-    if (store)
-      free(store);
-    if (ctx)
-      free(ctx);
-    return NULL;
-  }
+    if (!store || !ctx) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_ro_http_proxy: failed to allocate memory for context");
+        if (store) free(store); 
+        if (ctx) free(ctx); 
+        return NULL;
+    }
 
-  ctx->cache.x = -1;
-  ctx->cache.y = -1;
-  ctx->cache.z = -1;
-  ctx->cache.tile = NULL;
-  ctx->cache.xmlname[0] = 0;
+    ctx->cache.x = -1; ctx->cache.y = -1; ctx->cache.z = -1;
+    ctx->cache.tile = NULL;
+    ctx->cache.xmlname[0] = 0;
 
-  ctx->baseurl = strdup(&(connection_string[strlen("ro_http_proxy://")]));
-  pthread_mutex_lock(&qLock);
-  if (!done_global_init) {
-    log_message(STORE_LOGLVL_DEBUG,
-                "init_storage_ro_http_proxy: Global init of curl",
-                connection_string);
-    res = curl_global_init(CURL_GLOBAL_DEFAULT);
-    done_global_init = 1;
-  } else {
-    res = CURLE_OK;
-  }
-  pthread_mutex_unlock(&qLock);
-  if (res != CURLE_OK) {
-    log_message(
-        STORE_LOGLVL_ERR,
-        "init_storage_ro_http_proxy: failed to initialise global curl: %s",
-        curl_easy_strerror(res));
-    free(ctx);
-    free(store);
-    return NULL;
-  }
+    ctx->baseurl = strdup(&(connection_string[strlen("ro_http_proxy://")]));
+    pthread_mutex_lock(&qLock);
+    if (!done_global_init) {
+        log_message(STORE_LOGLVL_DEBUG,"init_storage_ro_http_proxy: Global init of curl", connection_string);
+        res = curl_global_init(CURL_GLOBAL_DEFAULT);
+        done_global_init = 1;
+    } else {
+        res = CURLE_OK;
+    }
+    pthread_mutex_unlock(&qLock);
+    if (res != CURLE_OK) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_ro_http_proxy: failed to initialise global curl: %s", curl_easy_strerror(res));
+        free(ctx);
+        free(store);
+        return NULL;
+    }
 
-  ctx->ctx = curl_easy_init();
-  if (!ctx->ctx) {
-    log_message(STORE_LOGLVL_ERR,
-                "init_storage_ro_http_proxy: failed to initialise curl");
-    free(ctx);
-    free(store);
-    return NULL;
-  }
+    ctx->ctx = curl_easy_init();
+    if (!ctx->ctx) {
+        log_message(STORE_LOGLVL_ERR,"init_storage_ro_http_proxy: failed to initialise curl");
+        free(ctx);
+        free(store);
+        return NULL;
+    }
 
-  curl_easy_setopt(ctx->ctx, CURLOPT_NOSIGNAL, 1L);
-  curl_easy_setopt(ctx->ctx, CURLOPT_FOLLOWLOCATION, 1L);
-  curl_easy_setopt(ctx->ctx, CURLOPT_USERAGENT, "mod_tile/1.0");
-  curl_easy_setopt(ctx->ctx, CURLOPT_FILETIME, 1L);
+    curl_easy_setopt(ctx->ctx, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(ctx->ctx, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(ctx->ctx, CURLOPT_USERAGENT, "mod_tile/1.0");
+    curl_easy_setopt(ctx->ctx, CURLOPT_FILETIME, 1L);
 
-  store->storage_ctx = ctx;
+    store->storage_ctx = ctx;
 
-  store->tile_read = &ro_http_proxy_tile_read;
-  store->tile_stat = &ro_http_proxy_tile_stat;
-  store->metatile_write = &ro_http_proxy_metatile_write;
-  store->metatile_delete = &ro_http_proxy_metatile_delete;
-  store->metatile_expire = &ro_http_proxy_metatile_expire;
-  store->tile_storage_id = &ro_http_proxy_tile_storage_id;
-  store->close_storage = &ro_http_proxy_close_storage;
+    store->tile_read = &ro_http_proxy_tile_read;
+    store->tile_stat = &ro_http_proxy_tile_stat;
+    store->metatile_write = &ro_http_proxy_metatile_write;
+    store->metatile_delete = &ro_http_proxy_metatile_delete;
+    store->metatile_expire = &ro_http_proxy_metatile_expire;
+    store->tile_storage_id = &ro_http_proxy_tile_storage_id;
+    store->close_storage = &ro_http_proxy_close_storage;
 
-  return store;
+    return store;
 #endif
 }


### PR DESCRIPTION
* Ran clang-format on `src/gen_tile.cpp`, `src/parameterize_style.cpp`
* Standardized usage of `{LOG_PRIORITY}: ` prefix in log messages
* Changed calls to `fprintf(stderr` to `syslog` calls
* Extended `renderd` log priority onto Mapnik's logger
* Reverted changes to `src/store_*.c`